### PR TITLE
Exclude pages not scanned from total scan count, include additional page data in Google sheets and bug fix for formatter in custom flow 

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -14,6 +14,7 @@ const combineRun = async (details, deviceToScan) => {
   const {
     type,
     url,
+    entryUrl,
     nameEmail,
     randomToken,
     deviceChosen,
@@ -127,7 +128,11 @@ const combineRun = async (details, deviceToScan) => {
 
   if (scanDetails.urlsCrawled.scanned.length > 0) {
     await createAndUpdateResultsFolders(randomToken);
-    const pagesNotScanned = [...urlsCrawled.error, ...urlsCrawled.invalid];
+    const pagesNotScanned = [
+      ...urlsCrawled.error, 
+      ...urlsCrawled.invalid, 
+      ...urlsCrawled.forbidden
+  ];
     const basicFormHTMLSnippet = await generateArtifacts(
       randomToken,
       url,
@@ -138,15 +143,19 @@ const combineRun = async (details, deviceToScan) => {
       customFlowLabel,
     );
     const [name, email] = nameEmail.split(':');
+    
     await submitForm(
       browser,
       userDataDirectory,
       url,
+      entryUrl,
       type,
       email,
       name,
       JSON.stringify(basicFormHTMLSnippet),
       urlsCrawled.scanned.length,
+      urlsCrawled.scannedRedirects.length, 
+      pagesNotScanned.length,
       metadata,
     );
   } else {

--- a/combine.js
+++ b/combine.js
@@ -132,7 +132,7 @@ const combineRun = async (details, deviceToScan) => {
       ...urlsCrawled.error, 
       ...urlsCrawled.invalid, 
       ...urlsCrawled.forbidden
-  ];
+    ];
     const basicFormHTMLSnippet = await generateArtifacts(
       randomToken,
       url,

--- a/constants/common.js
+++ b/constants/common.js
@@ -1258,7 +1258,6 @@ export const submitForm = async (
     `${formDataFields.additionalPageDataField}=${encodeURIComponent(addtionalPageDataJson)}&` + 
     `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
 
-  console.log(finalUrl);
   if (scannedUrl !== entryUrl) {
     finalUrl += `&${formDataFields.redirectUrlField}=${scannedUrl}`;
   }

--- a/constants/common.js
+++ b/constants/common.js
@@ -526,6 +526,7 @@ export const prepareData = argv => {
   return {
     type: scanner,
     url: finalUrl,
+    entryUrl: url,
     isHeadless: headless,
     deviceChosen,
     customDevice,
@@ -1229,23 +1230,32 @@ export const submitFormViaPlaywright = async (browserToRun, userDataDirectory, f
 export const submitForm = async (
   browserToRun,
   userDataDirectory,
-  websiteUrl,
+  scannedUrl,
+  entryUrl,
   scanType,
   email,
   name,
   scanResultsJson,
   numberOfPagesScanned,
+  numberOfRedirectsScanned,
+  numberOfPagesNotScanned,
   metadata,
 ) => {
-  const finalUrl =
+  let finalUrl =
     `${formDataFields.formUrl}?` +
-    `${formDataFields.websiteUrlField}=${websiteUrl}&` +
+    `${formDataFields.entryUrlField}=${entryUrl}&` +
     `${formDataFields.scanTypeField}=${scanType}&` +
     `${formDataFields.emailField}=${email}&` +
     `${formDataFields.nameField}=${name}&` +
     `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
     `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}&` +
+    `${formDataFields.numberOfRedirectsScannedField}=${numberOfRedirectsScanned}&` + 
+    `${formDataFields.numberOfPagesNotScannedField}=${numberOfPagesNotScanned}&` +
     `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
+
+  if (scannedUrl !== entryUrl) {
+    finalUrl += `&${formDataFields.redirectUrlField}=${scannedUrl}`;
+  }
 
   if (proxy) {
     await submitFormViaPlaywright(browserToRun, userDataDirectory, finalUrl);

--- a/constants/common.js
+++ b/constants/common.js
@@ -1241,6 +1241,12 @@ export const submitForm = async (
   numberOfPagesNotScanned,
   metadata,
 ) => {
+
+  const addtionalPageDataJson = JSON.stringify({
+    redirectsScanned: numberOfRedirectsScanned, 
+    pagesNotScanned: numberOfPagesNotScanned
+  })
+
   let finalUrl =
     `${formDataFields.formUrl}?` +
     `${formDataFields.entryUrlField}=${entryUrl}&` +
@@ -1249,10 +1255,10 @@ export const submitForm = async (
     `${formDataFields.nameField}=${name}&` +
     `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
     `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}&` +
-    `${formDataFields.numberOfRedirectsScannedField}=${numberOfRedirectsScanned}&` + 
-    `${formDataFields.numberOfPagesNotScannedField}=${numberOfPagesNotScanned}&` +
+    `${formDataFields.additionalPageDataField}=${encodeURIComponent(addtionalPageDataJson)}&` + 
     `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
 
+  console.log(finalUrl);
   if (scannedUrl !== entryUrl) {
     finalUrl += `&${formDataFields.redirectUrlField}=${scannedUrl}`;
   }

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -233,13 +233,16 @@ export const impactOrder = {
 
 export const formDataFields = {
   formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSem5C8fyNs5TiU5Vv2Y63-SH7CHN86f-LEPxeN_1u_ldUbgUA/formResponse`, // prod
-  // formUrl: `https://docs.google.com/forms/d/e/1FAIpQLScNldkNEajZbAiXK5TmMy4DfMERC2Sd7aJJrD76vBNz4pm05g/formResponse`, // dev
-  websiteUrlField: 'entry.1562345227',
+  // formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSfIOwd6DxKx4kASf68QbicK3tTmcby7VHMtKjvfrAf0VnZRfw/formResponse`, // dev
+  entryUrlField: 'entry.1562345227',
+  redirectUrlField: 'entry.473072563', 
   scanTypeField: 'entry.1148680657',
   emailField: 'entry.52161304',
   nameField: 'entry.1787318910',
   resultsField: 'entry.904051439',
   numberOfPagesScannedField: 'entry.238043773',
+  numberOfRedirectsScannedField: 'entry.2090887881',
+  numberOfPagesNotScannedField: 'entry.1034726094', 
   metadataField: 'entry.1027769131',
 };
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -233,16 +233,15 @@ export const impactOrder = {
 
 export const formDataFields = {
   formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSem5C8fyNs5TiU5Vv2Y63-SH7CHN86f-LEPxeN_1u_ldUbgUA/formResponse`, // prod
-  // formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSfIOwd6DxKx4kASf68QbicK3tTmcby7VHMtKjvfrAf0VnZRfw/formResponse`, // dev
+  // formUrl: `https://docs.google.com/forms/d/e/1FAIpQLSf69h2C7pv8k4fl3x2isbA9UnUaXWBsgZyRILuq2UNrIMYTqA/formResponse`, // dev
   entryUrlField: 'entry.1562345227',
   redirectUrlField: 'entry.473072563', 
   scanTypeField: 'entry.1148680657',
   emailField: 'entry.52161304',
   nameField: 'entry.1787318910',
   resultsField: 'entry.904051439',
-  numberOfPagesScannedField: 'entry.238043773',
-  numberOfRedirectsScannedField: 'entry.2090887881',
-  numberOfPagesNotScannedField: 'entry.1034726094', 
+  numberOfPagesScannedField: 'entry.238043773', 
+  additionalPageDataField: 'entry.2090887881',
   metadataField: 'entry.1027769131',
 };
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -157,6 +157,7 @@ const urlsCrawledObj = {
   exceededRequests: [],
   forbidden: [],
   userExcluded: [],
+  everything: [],
 };
 
 const scannerTypes = {

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -422,7 +422,7 @@ export const generateArtifacts = async (
 
   flattenAndSortResults(allIssues, isCustomFlow);
 
-  allIssues.totalPages = allIssues.totalPagesScanned + allIssues.totalPagesNotScanned;
+  // allIssues.totalPages = allIssues.totalPagesScanned;
 
   printMessage([
     'Scan Summary',

--- a/npmIndex.js
+++ b/npmIndex.js
@@ -195,6 +195,7 @@ export const init = async (
         constants.browserTypes.chromium,
         '',
         scanDetails.requestUrl,
+        null,
         scanDetails.crawlType,
         email,
         name,

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -890,7 +890,8 @@ const waitForCaptcha = async (page, captchaLocator) => {
 
     // format generated script
     const file = fs.readFileSync(generatedScript, 'utf8');
-    fs.writeFileSync(generatedScript, prettier.format(file, { parser: 'babel' }), 'utf8');
+    const formatter = await prettier.format(file, { parser: 'babel' })
+    fs.writeFileSync(generatedScript, formatter, 'utf8');
 
     fileStream.destroy();
     if (process.env.RUNNING_FROM_PH_GUI) {

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -428,6 +428,11 @@ const waitForCaptcha = async (page, captchaLocator) => {
             await createDetailsAndLogs(scanDetails, ${formatScriptStringVar(randomToken)});
             await createAndUpdateResultsFolders(${formatScriptStringVar(randomToken)});
             createScreenshotsFolder(${formatScriptStringVar(randomToken)});
+            const pagesNotScanned = [
+              ...urlsCrawled.error, 
+              ...urlsCrawled.invalid, 
+              ...urlsCrawled.forbidden
+          ];
             const basicFormHTMLSnippet = await generateArtifacts(
               ${formatScriptStringVar(randomToken)},
               ${formatScriptStringVar(data.url)},
@@ -438,7 +443,7 @@ const waitForCaptcha = async (page, captchaLocator) => {
                   : customDevice || deviceChosen || 'Desktop',
               )}, 
               urlsCrawled.scanned, 
-              urlsCrawled.error,
+              pagesNotScanned,
               ${formatScriptStringVar(customFlowLabel || 'Custom Flow')}
             );
 
@@ -446,12 +451,15 @@ const waitForCaptcha = async (page, captchaLocator) => {
     ${formatScriptStringVar(data.browser)},
     ${formatScriptStringVar(data.userDataDirectory)},
     ${formatScriptStringVar(data.url)},
+    ${formatScriptStringVar(data.entryUrl)},
     ${formatScriptStringVar(data.type)},
     // nameEmail = name:email
     ${formatScriptStringVar(data.nameEmail.split(':')[1])}, 
     ${formatScriptStringVar(data.nameEmail.split(':')[0])},
     JSON.stringify(basicFormHTMLSnippet),
     urlsCrawled.scanned.length,
+    urlsCrawled.scannedRedirects.length,
+    pagesNotScanned.length,
     "${data.metadata.replace(/"/g, '\\"')}",
   );
 

--- a/static/ejs/partials/components/pagesScannedModal.ejs
+++ b/static/ejs/partials/components/pagesScannedModal.ejs
@@ -9,7 +9,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title fw-bold" id="pagesScannedModalLabel">
-          <%= isCustomFlow ? customFlowLabel + ' (' + totalPages + ' pages)' : scanType + ' crawl' + ' (' + totalPages + ' pages)'%>
+          <%= isCustomFlow ? customFlowLabel + ' (' + totalPagesScanned + ' pages)' : scanType + ' crawl' + ' (' + totalPagesScanned + ' pages)'%>
         </h4>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>

--- a/static/ejs/partials/components/scanAbout.ejs
+++ b/static/ejs/partials/components/scanAbout.ejs
@@ -141,7 +141,7 @@
         id="pagesScannedModalToggle"
         data-bs-toggle="modal"
         data-bs-target="#pagesScannedModal"
-      ><%= isCustomFlow ? customFlowLabel + ' (' + totalPages + ' pages)' : scanType + ' crawl' + ' (' + totalPages + ' pages)'%>
+      ><%= isCustomFlow ? customFlowLabel + ' (' + totalPagesScanned + ' pages)' : scanType + ' crawl' + ' (' + totalPagesScanned + ' pages)'%>
       <% if (totalPagesNotScanned > 0) { %>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
           <path d="M12 19.875C9.91142 19.875 7.90838 19.0453 6.43153 17.5685C4.95468 16.0916 4.125 14.0886 4.125 12C4.125 9.91142 4.95468 7.90838 6.43153 6.43153C7.90838 4.95468 9.91142 4.125 12 4.125C14.0886 4.125 16.0916 4.95468 17.5685 6.43153C19.0453 7.90838 19.875 9.91142 19.875 12C19.875 14.0886 19.0453 16.0916 17.5685 17.5685C16.0916 19.0453 14.0886 19.875 12 19.875ZM12 21C14.3869 21 16.6761 20.0518 18.364 18.364C20.0518 16.6761 21 14.3869 21 12C21 9.61305 20.0518 7.32387 18.364 5.63604C16.6761 3.94821 14.3869 3 12 3C9.61305 3 7.32387 3.94821 5.63604 5.63604C3.94821 7.32387 3 9.61305 3 12C3 14.3869 3.94821 16.6761 5.63604 18.364C7.32387 20.0518 9.61305 21 12 21Z" fill="#D7260F"/>


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Handle page redirect and scan redirected URL if scanned pages is less than user input
- Exclude pages not scanned from total scan count and terminate crawler only when number of pages scanned successfully is matches value of maxRequestsPerCrawl 
- Submit number of redirects scanned and number of pages not scanned as a JSON object and redirected URL (if any) as new form inputs for Google form 
- Bug fix for formatter in Custom Flow 1.0

<!-- This checklist is just a guideline.
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [X] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1 reviewer
- [X] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
