### PR TITLE
adding xpath and axe impact to csv

### DIFF
--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -36,9 +36,13 @@ export const filterAxeResults = (needsReview, results, pageTitle, customFlowDeta
 
     const addTo = (category, node) => {
       const { html, failureSummary, screenshotPath, target } = node;
+      //add it here - delete later
+      console.log(node.impact);
       if (!(rule in category.rules)) {
-        category.rules[rule] = { description, helpUrl, conformance, totalItems: 0, items: [] };
+        category.rules[rule] = {description, helpUrl, conformance, totalItems: 0, items: [] };
       }
+      console.log(category.rules[rule]);
+      return;
       const message = displayNeedsReview
         ? failureSummary.slice(failureSummary.indexOf('\n') + 1).trim()
         : failureSummary;

--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -36,13 +36,10 @@ export const filterAxeResults = (needsReview, results, pageTitle, customFlowDeta
 
     const addTo = (category, node) => {
       const { html, failureSummary, screenshotPath, target } = node;
-      //add it here - delete later
-      console.log(node.impact);
+      const axeImpact = node.impact;
       if (!(rule in category.rules)) {
-        category.rules[rule] = {description, helpUrl, conformance, totalItems: 0, items: [] };
+        category.rules[rule] = {description,axeImpact, helpUrl, conformance, totalItems: 0, items: [] };
       }
-      console.log(category.rules[rule]);
-      return;
       const message = displayNeedsReview
         ? failureSummary.slice(failureSummary.indexOf('\n') + 1).trim()
         : failureSummary;
@@ -83,7 +80,7 @@ export const filterAxeResults = (needsReview, results, pageTitle, customFlowDeta
   }
 
   passes.forEach(item => {
-    const { id: rule, help: description, helpUrl, tags, nodes } = item;
+    const { id: rule, help: description, axeImpact, helpUrl, tags, nodes } = item;
 
     if (rule === 'frame-tested') return;
 
@@ -92,7 +89,7 @@ export const filterAxeResults = (needsReview, results, pageTitle, customFlowDeta
     nodes.forEach(node => {
       const { html } = node;
       if (!(rule in passed.rules)) {
-        passed.rules[rule] = { description, helpUrl, conformance, totalItems: 0, items: [] };
+        passed.rules[rule] = { description,axeImpact, helpUrl, conformance, totalItems: 0, items: [] };
       }
       passed.rules[rule].items.push({ html });
       passed.totalItems += 1;

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -76,7 +76,6 @@ const writeCsv = async (allIssues, storagePath) => {
     if (pageNum < 0) return 'Document';
     return `Page ${pageNum}`;
   };
-  console.log(allIssues.items.mustFix.rules);
 
   // transform allIssues into the form:
   // [['mustFix', rule1], ['mustFix', rule2], ['goodToFix', rule3], ...]
@@ -126,15 +125,15 @@ const writeCsv = async (allIssues, storagePath) => {
 
         results.push({
           severity,
-          axeImpact,
           issueId,
           issueDescription,
           wcagConformance,
           url,
           context,
           howToFix,
-          learnMore,
+          axeImpact,
           xpath,
+          learnMore,
         });
       });
     }
@@ -145,15 +144,15 @@ const writeCsv = async (allIssues, storagePath) => {
     transforms: [getRulesByCategory, flattenRule],
     fields: [
       'severity',
-      'axeImpact',
       'issueId',
       'issueDescription',
       'wcagConformance',
       'url',
       'context',
       'howToFix',
-      'learnMore',
+      'axeImpact',
       'xpath',
+      'learnMore',
     ],
     includeEmptyRows: true,
   };

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -94,6 +94,7 @@ const writeCsv = async (allIssues, storagePath) => {
         return compareCategory === 0 ? a[1].rule.localeCompare(b[1].rule) : compareCategory;
       });
   };
+  //seems to go into 
   const flattenRule = catAndRule => {
     const [severity, rule] = catAndRule;
     const results = [];


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- xpath and axe-impact fields into the CSV, axe-impact will also be displayed on the compiledResults.json as a result of the change.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
