### PR TITLE
Downgrade version of base docker image to alpine3.18 to resolve lib compatibility with Chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Node LTS alpine distribution
-FROM node:lts-alpine
+FROM node:lts-alpine3.18
 
 # Installation of packages for purple-a11y and chromium
 RUN apk add build-base gcompat g++ make python3 zip bash git chromium openjdk11-jre

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/purple-hats",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/purple-hats",
-      "version": "0.9.40",
+      "version": "0.9.41",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/purple-hats",
   "main": "npmIndex.js",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "type": "module",
   "imports": {
     "#root/*.js": "./*.js"


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Drop the version of lts-alpine docker image from (latest) 3.19 to 3.18 due to compatibility issues with Chromium from starting in docker
- Error log:
```
[pid=63][err] Error relocating /opt/ms-playwright/chromium-1091/chrome-linux/chrome: posix_fallocate64: symbol not found
```
- Issue: https://github.com/nodejs/docker-node/pull/2007
- Described changes: https://github.com/docker-library/official-images/pull/15876/commits/288b1e06920c8783e010bd899d6653f730e75b07#diff-f8918c0b7c7e8cbf69597e2a59b32ad6e1d69824d5f3358f72ce1201aa9e0f7eR77
- Detailed error log:
```
{"timestamp":"2023-12-14 07:31:16","level":"error","message":"uncaughtException: Failed to launch browser. Please check the following:\n- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).\n\nThe original error is available in the `cause` property. Below is the error received when trying to launch a browser:\n​\nFailed to launch browser. Please check the following:\n- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).\n\nThe original error is available in the `cause` property. Below is the error received when trying to launch a browser:\n​\nbrowserType.launchPersistentContext: Target page, context or browser has been closed\nBrowser logs:\n\n<launching> /opt/ms-playwright/chromium-1091/chrome-linux/chrome --disable-field-trial-config --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --headless --hide-scrollbars --mute-audio --blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4 --no-sandbox --proxy-server=http://127.0.0.1:33991/ --proxy-bypass-list=<-loopback> --disable-gpu --no-sandbox --disable-dev-shm-usage --disable-blink-features=AutomationControlled --user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 --user-data-dir=/tmp/playwright_chromiumdev_profile-fFngdD --remote-debugging-pipe about:blank\n<launched> pid=63\n[pid=63][err] Error relocating /opt/ms-playwright/chromium-1091/chrome-linux/chrome: posix_fallocate64: symbol not found\nCall log:\n  - <launching> /opt/ms-playwright/chromium-1091/chrome-linux/chrome --disable-field-trial-config --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --headless --hide-scrollbars --mute-audio --blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4 --no-sandbox --proxy-server=http://127.0.0.1:33991/ --proxy-bypass-list=<-loopback> --disable-gpu --no-sandbox --disable-dev-shm-usage --disable-blink-features=AutomationControlled --user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 --user-data-dir=/tmp/playwright_chromiumdev_profile-fFngdD --remote-debugging-pipe about:blank\n  - <launched> pid=63\n  - [pid=63][err] Error relocating /opt/ms-playwright/chromium-1091/chrome-linux/chrome: posix_fallocate64: symbol not found\n\n    at async PlaywrightPlugin._launch (/app/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:105:40)\n    at async BrowserPool._launchBrowser (/app/node_modules/@crawlee/browser-pool/browser-pool.js:465:29)\n    at /app/async /app/node_modules/@crawlee/browser-pool/browser-pool.js:274:37\nError thrown at:\n\n    at PlaywrightPlugin._throwAugmentedLaunchError (/app/node_modules/@crawlee/browser-pool/abstract-classes/browser-plugin.js:145:15)\n    at PlaywrightPlugin._throwOnFailedLaunch (/app/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:161:14)\n    at /app/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:106:33\n    at async PlaywrightPlugin._launch (/app/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:105:40)\n    at async BrowserPool._launchBrowser (/app/node_modules/@crawlee/browser-pool/browser-pool.js:465:29)\n    at async /app/node_modules/@crawlee/browser-pool/browser-pool.js:274:37"}
```

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [x] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
