### PR TITLE
Support basic authentication in sitemap scan and option to adhere to robots.txt rules

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -257,6 +257,7 @@ const scanInit = async argvs => {
     argvs.scanner = constants.scannerTypes[argvs.scanner];
   }
   argvs.headless = argvs.headless === 'yes';
+  argvs.followRobots = argvs.followRobots === 'yes';
   argvs.browserToRun = constants.browserTypes[argvs.browserToRun];
 
   // let chromeDataDir = null;
@@ -350,7 +351,7 @@ const scanInit = async argvs => {
     constants.exportDirectory = argvs.exportDirectory;
   }
 
-  const data = prepareData(argvs);
+  const data = await prepareData(argvs);
 
   setHeadlessMode(data.browser, data.isHeadless);
 

--- a/combine.js
+++ b/combine.js
@@ -32,6 +32,7 @@ const combineRun = async (details, deviceToScan) => {
     blacklistedPatternsFilename,
     includeScreenshots,
     metadata,
+    disallowedUrls,
     customFlowLabel = 'Custom Flow',
   } = envDetails;
 
@@ -113,6 +114,7 @@ const combineRun = async (details, deviceToScan) => {
         fileTypes,
         blacklistedPatterns,
         includeScreenshots,
+        disallowedUrls
       );
       break;
 

--- a/combine.js
+++ b/combine.js
@@ -96,6 +96,7 @@ const combineRun = async (details, deviceToScan) => {
         fileTypes,
         blacklistedPatterns,
         includeScreenshots,
+        disallowedUrls
       );
       break;
 

--- a/combine.js
+++ b/combine.js
@@ -32,7 +32,6 @@ const combineRun = async (details, deviceToScan) => {
     blacklistedPatternsFilename,
     includeScreenshots,
     metadata,
-    disallowedUrls,
     customFlowLabel = 'Custom Flow',
   } = envDetails;
 
@@ -95,8 +94,7 @@ const combineRun = async (details, deviceToScan) => {
         needsReviewItems,
         fileTypes,
         blacklistedPatterns,
-        includeScreenshots,
-        disallowedUrls
+        includeScreenshots
       );
       break;
 
@@ -114,8 +112,7 @@ const combineRun = async (details, deviceToScan) => {
         needsReviewItems,
         fileTypes,
         blacklistedPatterns,
-        includeScreenshots,
-        disallowedUrls
+        includeScreenshots
       );
       break;
 

--- a/combine.js
+++ b/combine.js
@@ -31,6 +31,7 @@ const combineRun = async (details, deviceToScan) => {
     fileTypes,
     blacklistedPatternsFilename,
     includeScreenshots,
+    followRobots,
     metadata,
     customFlowLabel = 'Custom Flow',
   } = envDetails;
@@ -112,7 +113,8 @@ const combineRun = async (details, deviceToScan) => {
         needsReviewItems,
         fileTypes,
         blacklistedPatterns,
-        includeScreenshots
+        includeScreenshots,
+        followRobots
       );
       break;
 

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -143,6 +143,15 @@ export const cliOptions = {
     default: '{}',
     demandOption: false,
   },
+  r: {
+    alias: 'followRobots', 
+    describe: 'Option for crawler to adhere to robots.txt rules if it exists', 
+    type: 'string', 
+    choices: ['yes', 'no'],
+    requiresArg: true,
+    default: 'no',
+    demandOption: false,
+  }
 };
 
 export const configureReportSetting = isEnabled => {

--- a/constants/common.js
+++ b/constants/common.js
@@ -559,7 +559,6 @@ export const prepareData = async argv => {
 };
 
 export const getUrlsFromRobotsTxt = async (url, browserToRun) => {
-  console.log(constants.robotsTxtUrls);
   if (!constants.robotsTxtUrls) return; 
 
   const domain = new URL(url).origin;
@@ -623,7 +622,6 @@ export const getUrlsFromRobotsTxt = async (url, browserToRun) => {
     }
   }
   constants.robotsTxtUrls[domain] = { disallowedUrls, allowedUrls };  
-  console.log(constants.robotsTxtUrls);
 }
 
 const getRobotsTxtViaPlaywright = async (robotsUrl, browser) => {
@@ -678,7 +676,6 @@ export const getLinksFromSitemap = async (
   maxLinksCount,
   browser,
   userDataDirectory,
-  disallowedUrls
 ) => {
   const urls = {}; // dictionary of requests to urls to be scanned
 

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -16,7 +16,8 @@ import {
   getPlaywrightLaunchOptions,
   isBlacklistedFileExtensions,
   isSkippedUrl,
-  isDisallowedInRobotsTxt
+  isDisallowedInRobotsTxt,
+  getUrlsFromRobotsTxt
 } from '../constants/common.js';
 import { areLinksEqual } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -37,6 +38,7 @@ const crawlDomain = async (
   fileTypes,
   blacklistedPatterns,
   includeScreenshots,
+  followRobots
 ) => {
   let needsReview = needsReviewItems;
   const isScanHtml = ['all', 'html-only'].includes(fileTypes);
@@ -349,6 +351,7 @@ const crawlDomain = async (
             urlsCrawled.blacklisted.push(request.url);
           }
 
+          if (followRobots) await getUrlsFromRobotsTxt(request.url, browser);
           await enqueueProcess(page, enqueueLinks, enqueueLinksByClickingElements);
         }
       } catch (e) {

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -110,11 +110,7 @@ const crawlSitemap = async (
       const actualUrl = request.loadedUrl || request.url;
 
       if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) {
-        guiInfoLog(guiInfoStatusTypes.SKIPPED, {
-          numScanned: urlsCrawled.scanned.length,
-          urlScanned: request.url,
-        });
-        urlsCrawled.exceededRequests.push(request.url);
+        crawler.autoscaledPool.abort();
         return;
       }
 

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -32,8 +32,7 @@ const crawlSitemap = async (
   needsReviewItems,
   fileTypes,
   blacklistedPatterns,
-  includeScreenshots,
-  disallowedUrls
+  includeScreenshots
 ) => {
 
    // Boolean to omit axe scan for basic auth URL
@@ -71,7 +70,7 @@ const crawlSitemap = async (
   const uuidToPdfMapping = {};
 
   printMessage(['Fetching URLs. This might take some time...'], { border: false });
-  const linksFromSitemap = await getLinksFromSitemap(sitemapUrl, maxRequestsPerCrawl, browser, userDataDirectory, disallowedUrls)
+  const linksFromSitemap = await getLinksFromSitemap(sitemapUrl, maxRequestsPerCrawl, browser, userDataDirectory)
   finalLinks = [...finalLinks, ...linksFromSitemap];
 
   const requestList = new crawlee.RequestList({

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -33,6 +33,7 @@ const crawlSitemap = async (
   fileTypes,
   blacklistedPatterns,
   includeScreenshots,
+  disallowedUrls
 ) => {
 
    // Boolean to omit axe scan for basic auth URL
@@ -70,7 +71,7 @@ const crawlSitemap = async (
   const uuidToPdfMapping = {};
 
   printMessage(['Fetching URLs. This might take some time...'], { border: false });
-  const linksFromSitemap = await getLinksFromSitemap(sitemapUrl, maxRequestsPerCrawl, browser, userDataDirectory)
+  const linksFromSitemap = await getLinksFromSitemap(sitemapUrl, maxRequestsPerCrawl, browser, userDataDirectory, disallowedUrls)
   finalLinks = [...finalLinks, ...linksFromSitemap];
 
   const requestList = new crawlee.RequestList({
@@ -204,7 +205,6 @@ const crawlSitemap = async (
           }
           await dataset.pushData(results);
         } else {
-          console.log('SKIPPED: ', status, ' WHITELISTED: ', isWhitelistedContentType(contentType));
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "inquirer": "^9.2.12",
         "jsdom": "^21.1.2",
         "lodash": "^4.17.21",
+        "minimatch": "^9.0.3",
         "pdfjs-dist": "github:veraPDF/pdfjs-dist#v2.14.305-taggedPdf-0.1.11",
         "playwright": "1.40.0",
         "prettier": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "inquirer": "^9.2.12",
     "jsdom": "^21.1.2",
     "lodash": "^4.17.21",
+    "minimatch": "^9.0.3",
     "pdfjs-dist": "github:veraPDF/pdfjs-dist#v2.14.305-taggedPdf-0.1.11",
     "playwright": "1.40.0",
     "prettier": "^3.1.0",


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Include basic auth credentials in sitemap scan 
- Adhere to robots.txt rules in website and sitemap scans 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
