### PR TITLE
fix/Custom flow 2.0 bar does not appear on all pages

### DIFF
--- a/crawlers/custom/utils.js
+++ b/crawlers/custom/utils.js
@@ -319,7 +319,30 @@ export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
 
         shadowRoot.appendChild(menu);
 
-        document.body.appendChild(shadowHost);
+        let currentNode = document.body
+        if (document.body) {
+          // The <body> element exists
+          if ( document.body.nodeName.toLowerCase() === 'frameset') {
+              // if currentNode is a <frameset>
+              // Move the variable outside the frameset then appendChild the component
+              while (currentNode.nodeName.toLowerCase()=== 'frameset' ) {
+                currentNode = currentNode.parentElement
+              }
+              currentNode.appendChild(shadowHost);
+            } else {
+              // currentNode is a <body>
+              currentNode.appendChild(shadowHost);
+            }
+        } else if (document.head) {
+          // The <head> element exists
+          // Append the variable below the head
+          head.insertAdjacentElement('afterend', shadowHost);
+        } else {
+          // Neither <body> nor <head> nor <html> exists
+          // Append the variable to the document
+          document.documentElement.appendChild(shadowHost);
+        }
+
       },
       { menuPos, MENU_POSITION, urlsCrawled },
     )


### PR DESCRIPTION
This PR adds... 

- Custom flow 2.0 bar does not appear on pages which HTML contained within `<frameset>`

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
NIL
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
NIL
