### PR TITLE
improv: purpleA11y instance to terminate upon threshold being exceeded

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -100,11 +100,11 @@ Parameter(s):
 Returns:
 - Object containing the number of mustFix and goodToFix issue occurrences for this scan run e.g. `{ mustFix: 1, goodToFix: 5 }`
 
-`testThresholdsAndReset()`
+`testThresholds()`
 
-Checks the accumulated issue occurrences count against the specified threshold and resets the issues count
+Checks the accumulated issue occurrences count against the specified threshold.
 
-- Throws an error if the number of accumulated mustFix or goodToFix issue occurrences exceeds either of the specified thresholds
+- Terminates purpleA11y instance and throws an error if the number of accumulated mustFix or goodToFix issue occurrences exceeds either of the specified thresholds
 
 `async terminate()`
 
@@ -197,7 +197,7 @@ Create <code>cypress.config.js</code> with the following contents, and change yo
                         return `results/${purpleA11y.randomToken}_${purpleA11y.scanDetails.urlsCrawled.scanned.length}pages/reports/report.html`;
                     },
                     finishPurpleA11yTestCase() {
-                        purpleA11y.testThresholdsAndReset();
+                        purpleA11y.testThresholds();
                         return null;
                     },
                     async terminatePurpleA11y() {
@@ -223,11 +223,9 @@ Create a sub-folder and file <code>cypress/support/e2e.js</code> with the follow
             const { elementsToScan, elementsToClick, metadata } = items; 
             const res = await win.runA11yScan(elementsToScan);
             cy.task("pushPurpleA11yScanResults", {res, metadata, elementsToClick}).then((count) => { return count });
+            cy.task("pushPurpleA11yScanResults", {res, metadata, elementsToClick}).then((count) => { return count });
+            cy.task("finishPurpleA11yTestCase"); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
         });
-    });
-
-    Cypress.Commands.add("finishPurpleA11yTestCase", () => {
-        cy.task("finishPurpleA11yTestCase");
     });
 
     Cypress.Commands.add("terminatePurpleA11y", () => {
@@ -250,8 +248,6 @@ Create <code>cypress/e2e/spec.cy.js</code> with the following contents:
                 elementsToClick: ["button[onclick=\"toggleSecondSection()\"]"],
                 metadata: "Clicked button"
             });
-
-            cy.finishPurpleA11yTestCase(); // test the number of issue occurrences against specified thresholds
 
             cy.terminatePurpleA11y();
         });
@@ -321,7 +317,7 @@ On your project's root folder, create a Playwright test file <code>purpleA11y-pl
         // Run a scan on <input> and <button> elements
         await runPurpleA11yScan(['input', 'button'])
 
-        purpleA11y.testThresholdsAndReset(); // test the number of issue occurrences against specified thresholds
+        purpleA11y.testThresholds(); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
 
         // ---------------------
         await context.close();

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -307,6 +307,7 @@ On your project's root folder, create a Playwright test file <code>purpleA11y-pl
                 elementsToScan,
             );
             await purpleA11y.pushScanResults(scanRes);
+            purpleA11y.testThresholds(); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
         };
 
         await page.goto('https://govtechsg.github.io/purple-banner-embeds/purple-integrated-scan-example.htm');
@@ -317,7 +318,6 @@ On your project's root folder, create a Playwright test file <code>purpleA11y-pl
         // Run a scan on <input> and <button> elements
         await runPurpleA11yScan(['input', 'button'])
 
-        purpleA11y.testThresholds(); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
 
         // ---------------------
         await context.close();

--- a/npmIndex.js
+++ b/npmIndex.js
@@ -140,7 +140,7 @@ export const init = async (
     };
   };
 
-  const testThresholdsAndReset = () => {
+  const testThresholds = () => {
     // check against thresholds to fail tests
     let isThresholdExceeded = false;
     let thresholdFailMessage = "Exceeded thresholds:\n";
@@ -154,11 +154,12 @@ export const init = async (
       thresholdFailMessage += `goodToFix occurrences found: ${goodToFixIssues} > ${goodToFixThreshold}\n`;
     }
 
-    // reset counts
-    mustFixIssues = 0;
-    goodToFixIssues = 0;
+    // uncomment to reset counts if you do not want violations count to be cumulative across other pages
+    // mustFixIssues = 0;
+    // goodToFixIssues = 0;
 
     if (isThresholdExceeded) {
+      terminate(); //terminate if threshold exceeded
       throw new Error(thresholdFailMessage);
     }
   };
@@ -215,7 +216,7 @@ export const init = async (
     terminate,
     scanDetails,
     randomToken,
-    testThresholdsAndReset,
+    testThresholds,
   };
 };
 


### PR DESCRIPTION
This PR adds... 

-changed behaviour of testThresholdsAndReset() to not reset the count of violations, and renamed the function to testThresholds().
-edited custom cypress function so that in spec file, when cy.runPurpleA11yScan() is called, testThreshold is executed after scan as well.
-updated integration.md file for description of testThreshold function accordingly.


- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
NIL
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
NIL
