### PR TITLE
Fix behavour of node index for userData.txt not created and run in background

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,11 @@ const runScan = async answers => {
   let { browserToRun, clonedDataDir } = getBrowserToRun(constants.browserTypes.chrome);
   deleteClonedProfiles(browserToRun);
   answers.browserToRun = browserToRun;
-  answers.nameEmail = `${userData.name}:${userData.email}`;
+
+  if (!answers.nameEmail) {
+    answers.nameEmail = `${userData.name}:${userData.email}`;
+  }
+
   answers.fileTypes = 'html-only';
   answers.metadata = '{}';
 
@@ -49,7 +53,7 @@ const runScan = async answers => {
     isNewCustomFlow = true;
   }
 
-  const data = prepareData(answers);
+  const data = await prepareData(answers);
   clonedDataDir = getClonedProfilesWithRandomToken(data.browser, data.randomToken);
   data.userDataDirectory = clonedDataDir;
 
@@ -122,8 +126,8 @@ if (userData) {
   );
 
   inquirer.prompt(questions).then(async answers => {
-    const { name, email } = answers;
-
+    const { name, email} = answers;
+    answers.nameEmail = `${name}:${email}`;
     await writeToUserDataTxt('name', name);
     await writeToUserDataTxt('email', email);
 

--- a/utils.js
+++ b/utils.js
@@ -80,11 +80,12 @@ export const writeToUserDataTxt = async (key, value) => {
           'Purple A11y',
           'userData.txt',
         );
+
   // Create file if it doesn't exist
   if (fs.existsSync(textFilePath)) {
     const userData = JSON.parse(fs.readFileSync(textFilePath, 'utf8'));
     userData[key] = value;
-    await fs.writeFile(textFilePath, JSON.stringify(userData, 0, 2));
+    fs.writeFileSync(textFilePath, JSON.stringify(userData, 0, 2));
   } else {
     const textFilePathDir = path.dirname(textFilePath);
     if (!fs.existsSync(textFilePathDir)) {


### PR DESCRIPTION

This PR adds... <!-- A brief description of what your PR does -->
- Fixes behaviour of node index error due to userData not created on first run, but works on subsequent run
- Fixes run in background in node index

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
