### PR TITLE
Add a flag in CLI to accept authentication headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,13 +290,17 @@ Options:
   -r, --followRobots                 Option for crawler to adhere to robots.txt
                                      rules if it exists
                                  [string] [choices: "yes", "no"] [default: "no"]
+  -m, --header                       The HTTP authentication header keys and the
+                                     ir respective values to enable crawler acce
+                                     ss to restricted resources.        [string]
+
 Examples:
-  To scan sitemap of website:', 'node cli.js -c [ 1 | Sitemap ] -d <device> -u
-   <url_link> -w <viewportWidth>
-  To scan a website', 'node cli.js -c [ 2 | Website ] -d <device> -u <url_link
-  > -w <viewportWidth>
-  To start a custom flow scan', 'node cli.js -c [ 3 | Custom ] -d <device> -u
-  <url_link> -w <viewportWidth>
+  To scan sitemap of website:', 'node cli.js -c [ 1 | sitemap ] -u <url_link>
+  [ -d <device> | -w <viewport_width> ]
+  To scan a website', 'node cli.js -c [ 2 | website ] -u <url_link> [ -d <devi
+  ce> | -w <viewport_width> ]
+  To start a custom flow scan', 'node cli.js -c [ 3 | custom ] -u <url_link> [
+   -d <device> | -w <viewport_width> ]
 ```
 
 ### Device Options

--- a/cli.js
+++ b/cli.js
@@ -242,14 +242,15 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
       if (headerValuePair.length < 2) {
         printMessage(
           [
-            `Invalid value for request header. Please provide valid keywords in the format: "<key> <value>". For multiple authentication headers, please provide the keywords in the format:  "<key> <value>, <key2> <value2>, ..." .`,
+            `Invalid value for authorisation request header. Please provide valid keywords in the format: "<header> <value>". For multiple authentication headers, please provide the keywords in the format:  "<header> <value>, <header2> <value2>, ..." .`,
           ],
           messageOptions,
         );
         process.exit(1);
       }
-      allHeaders[headerValuePair[0]] = headerValuePair[1]; // {key1: "val1", key2: val2,....,,,}  node 
+      allHeaders[headerValuePair[0]] = headerValuePair[1]; // {"header": "value", "header2": "value2", ...}
     });
+    
     return allHeaders;
   })
   .check(argvs => {

--- a/cli.js
+++ b/cli.js
@@ -233,6 +233,25 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     }
     return option;
   })
+  .coerce('m', option => {
+    const headerValues = option.split(', ');
+    const allHeaders = {};
+
+    headerValues.map(headerValue => {
+      const headerValuePair = headerValue.split(' ');
+      if (!headerValuePair.length === 2) {
+        printMessage(
+          [
+            `Invalid value for request header. Please provide valid keywords in the format: "<key> <value>". For multiple authentication headers, please provide the keywords in the format:  "<key> <value>, <key2> <value2>, ..." .`,
+          ],
+          messageOptions,
+        );
+        process.exit(1);
+      }
+      allHeaders[headerValuePair[0]] = headerValuePair[1]; // {key1: "val1", key2: val2,....,,,}  node 
+    });
+    return allHeaders;
+  })
   .check(argvs => {
     if ((argvs.scanner === 'custom' || argvs.scanner === 'custom2') && argvs.maxpages) {
       throw new Error('-p or --maxpages is only available in website and sitemap scans.');
@@ -289,7 +308,8 @@ const scanInit = async argvs => {
     argvs.browserToRun,
     clonedDataDir,
     argvs.playwrightDeviceDetailsObject,
-    isNewCustomFlow
+    isNewCustomFlow,
+    argvs.header,
   );
   switch (res.status) {
     case statuses.success.code:

--- a/cli.js
+++ b/cli.js
@@ -238,8 +238,8 @@ Usage: node cli.js -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     const allHeaders = {};
 
     headerValues.map(headerValue => {
-      const headerValuePair = headerValue.split(' ');
-      if (!headerValuePair.length === 2) {
+      const headerValuePair = headerValue.split(/ (.*)/s);
+      if (headerValuePair.length < 2) {
         printMessage(
           [
             `Invalid value for request header. Please provide valid keywords in the format: "<key> <value>". For multiple authentication headers, please provide the keywords in the format:  "<key> <value>, <key2> <value2>, ..." .`,

--- a/combine.js
+++ b/combine.js
@@ -34,6 +34,7 @@ const combineRun = async (details, deviceToScan) => {
     followRobots,
     metadata,
     customFlowLabel = 'Custom Flow',
+    extraHTTPHeaders
   } = envDetails;
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
@@ -95,7 +96,8 @@ const combineRun = async (details, deviceToScan) => {
         needsReviewItems,
         fileTypes,
         blacklistedPatterns,
-        includeScreenshots
+        includeScreenshots,
+        extraHTTPHeaders
       );
       break;
 
@@ -114,7 +116,8 @@ const combineRun = async (details, deviceToScan) => {
         fileTypes,
         blacklistedPatterns,
         includeScreenshots,
-        followRobots
+        followRobots,
+        extraHTTPHeaders
       );
       break;
 

--- a/constants/cliFunctions.js
+++ b/constants/cliFunctions.js
@@ -144,14 +144,22 @@ export const cliOptions = {
     demandOption: false,
   },
   r: {
-    alias: 'followRobots', 
-    describe: 'Option for crawler to adhere to robots.txt rules if it exists', 
-    type: 'string', 
+    alias: 'followRobots',
+    describe: 'Option for crawler to adhere to robots.txt rules if it exists',
+    type: 'string',
     choices: ['yes', 'no'],
     requiresArg: true,
     default: 'no',
     demandOption: false,
-  }
+  },
+  m: {
+    alias: 'header',
+    describe:
+      'The HTTP authentication header keys and their respective values to enable crawler access to restricted resources.',
+    type: 'string',
+    requiresArg: true,
+    demandOption: false,
+  },
 };
 
 export const configureReportSetting = isEnabled => {

--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -158,11 +158,15 @@ export const createCrawleeSubFolders = async randomToken => {
   return { dataset, requestQueue };
 };
 
-export const preNavigationHooks = [
-  async (_crawlingContext, gotoOptions) => {
+export const preNavigationHooks = (extraHTTPHeaders) => {
+  return [
+  async (crawlingContext, gotoOptions) => {
+    if (extraHTTPHeaders) {
+      crawlingContext.request.headers = extraHTTPHeaders;
+    }
     gotoOptions = { waitUntil: 'networkidle', timeout: 30000 };
   },
-];
+]};
 
 export const postNavigationHooks = [
   async _crawlingContext => {

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -38,7 +38,8 @@ const crawlDomain = async (
   fileTypes,
   blacklistedPatterns,
   includeScreenshots,
-  followRobots
+  followRobots,
+  extraHTTPHeaders
 ) => {
   let needsReview = needsReviewItems;
   const isScanHtml = ['all', 'html-only'].includes(fileTypes);
@@ -213,7 +214,7 @@ const crawlDomain = async (
       ],
     },
     requestQueue,
-    preNavigationHooks,
+    preNavigationHooks: preNavigationHooks(extraHTTPHeaders),
     requestHandler: async ({
       browserController,
       page,

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -85,7 +85,7 @@ const crawlDomain = async (
       strategy,
       requestQueue,
       transformRequestFunction(req) {
-        if (isDisallowedInRobotsTxt(req.url)) return null; 
+        if (isDisallowedInRobotsTxt(req.url)) return null;
         if (isUrlPdf(req.url)) {
           // playwright headless mode does not support navigation to pdf document
           req.skipNavigation = true;
@@ -116,12 +116,12 @@ const crawlDomain = async (
           if (route.request().resourceType() === 'document') {
             try {
               const isTopFrameNavigationRequest = () => {
-                return route.request().isNavigationRequest() 
-                    && route.request().frame() === page.mainFrame();
+                return route.request().isNavigationRequest()
+                  && route.request().frame() === page.mainFrame();
               }
 
               if (isTopFrameNavigationRequest()) {
-                const url = route.request().url(); 
+                const url = route.request().url();
                 if (!isDisallowedInRobotsTxt(url)) {
                   await requestQueue.addRequest({ url, skipNavigation: isUrlPdf(url) });
                 }
@@ -147,29 +147,29 @@ const crawlDomain = async (
     }
 
     page.on('request', async request => {
-      // Intercepting requests to handle cases where request was issued before the frame is created
-      await page.context().route(request.url(), async route => {
-          try {
-            const isTopFrameNavigationRequest = () => {
-            return route.request().isNavigationRequest() 
-                && route.request().frame() === page.mainFrame();
-            }
+      try {
+        // Intercepting requests to handle cases where request was issued before the frame is created
+        await page.context().route(request.url(), async route => {
+          const isTopFrameNavigationRequest = () => {
+            return route.request().isNavigationRequest()
+              && route.request().frame() === page.mainFrame();
+          }
 
-            if (route.request().resourceType() === 'document') {
-              if (isTopFrameNavigationRequest()) {
-                const url = route.request().url(); 
-                if (!isDisallowedInRobotsTxt(url)){
-                  await requestQueue.addRequest({ url, skipNavigation: isUrlPdf(url) });
-                }
+          if (route.request().resourceType() === 'document') {
+            if (isTopFrameNavigationRequest()) {
+              const url = route.request().url();
+              if (!isDisallowedInRobotsTxt(url)) {
+                await requestQueue.addRequest({ url, skipNavigation: isUrlPdf(url) });
               }
             }
-          } catch (e) {
-            silentLogger.info(e);
           }
         })
-      })
+      } catch (e) {
+        silentLogger.info(e);
+      }
+    })
 
-    // Try catch is necessary clicking links is best effort, it may result in new pages that cause browser load or navigation errors that PlaywrightCrawler does not handle
+    // Try catch is necessary as clicking links is best effort, it may result in new pages that cause browser load or navigation errors that PlaywrightCrawler does not handle
     try {
       await enqueueLinksByClickingElements({
         // set selector matches
@@ -179,8 +179,8 @@ const crawlDomain = async (
         // handle onclick
         selector: ':not(a):is([role="link"], button[onclick])',
         transformRequestFunction(req) {
-          if (isDisallowedInRobotsTxt(req.url)) return null; 
-          req.url = req.url.replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');        
+          if (isDisallowedInRobotsTxt(req.url)) return null;
+          req.url = req.url.replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');
           if (isUrlPdf(req.url)) {
             // playwright headless mode does not support navigation to pdf document
             req.skipNavigation = true;
@@ -226,7 +226,7 @@ const crawlDomain = async (
     }) => {
       // loadedUrl is the URL after redirects
       const actualUrl = request.loadedUrl || request.url;
-      
+
       if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) {
         crawler.autoscaledPool.abort();
         return;
@@ -234,13 +234,13 @@ const crawlDomain = async (
 
       if (isDisallowedInRobotsTxt(request.url)) {
         await enqueueProcess(page, enqueueLinks, enqueueLinksByClickingElements);
-        return; 
+        return;
       }
 
       // handle pdfs
       if (request.skipNavigation && isUrlPdf(actualUrl)) {
         if (!isScanPdfs) {
-          guiInfoLog(guiInfoStatusTypes.SKIPPED, {            
+          guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
           });
@@ -316,14 +316,14 @@ const crawlDomain = async (
               numScanned: urlsCrawled.scanned.length,
               urlScanned: request.url,
             });
-  
+
             // For deduplication, if the URL is redirected, we want to store the original URL and the redirected URL (actualUrl)
             const isRedirected = !areLinksEqual(request.loadedUrl, request.url);
             if (isRedirected) {
               const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(
                 item => (item.actualUrl || item.url) === request.loadedUrl,
               );
-  
+
               if (isLoadedUrlInCrawledUrls) {
                 urlsCrawled.notScannedRedirects.push({
                   fromUrl: request.url,
@@ -331,24 +331,33 @@ const crawlDomain = async (
                 });
                 return;
               }
-  
-              urlsCrawled.scanned.push({
-                url: request.url,
-                pageTitle: results.pageTitle,
-                actualUrl: request.loadedUrl, // i.e. actualUrl
-              });
-  
-              urlsCrawled.scannedRedirects.push({
-                fromUrl: request.url,
-                toUrl: request.loadedUrl, // i.e. actualUrl
-              });
-  
-              results.url = request.url;
-              results.actualUrl = request.loadedUrl;
+
+              // One more check if scanned pages have reached limit due to multi-instances of handler running
+              if (urlsCrawled.scanned.length < maxRequestsPerCrawl) {
+                urlsCrawled.scanned.push({
+                  url: request.url,
+                  pageTitle: results.pageTitle,
+                  actualUrl: request.loadedUrl, // i.e. actualUrl
+                });
+
+                urlsCrawled.scannedRedirects.push({
+                  fromUrl: request.url,
+                  toUrl: request.loadedUrl, // i.e. actualUrl
+                });
+
+                results.url = request.url;
+                results.actualUrl = request.loadedUrl;
+                await dataset.pushData(results);
+              }
             } else {
-              urlsCrawled.scanned.push({ url: request.url, pageTitle: results.pageTitle });
+
+              // One more check if scanned pages have reached limit due to multi-instances of handler running
+              if (urlsCrawled.scanned.length < maxRequestsPerCrawl) {
+                urlsCrawled.scanned.push({ url: request.url, pageTitle: results.pageTitle });
+                await dataset.pushData(results);
+              }
             }
-            await dataset.pushData(results);
+
           } else {
             guiInfoLog(guiInfoStatusTypes.SKIPPED, {
               numScanned: urlsCrawled.scanned.length,
@@ -361,7 +370,7 @@ const crawlDomain = async (
           await enqueueProcess(page, enqueueLinks, enqueueLinksByClickingElements);
         }
       } catch (e) {
-        if (!e.message.contains("page.evaluate")) {
+        if (!e.message.includes("page.evaluate")) {
           silentLogger.info(e);
           guiInfoLog(guiInfoStatusTypes.ERROR, {
             numScanned: urlsCrawled.scanned.length,
@@ -370,7 +379,7 @@ const crawlDomain = async (
           const browser = browserController.browser;
           page = await browser.newPage();
           await page.goto(request.url);
-  
+
           await page.route('**/*', async route => {
             const interceptedRequest = route.request();
             if (interceptedRequest.resourceType() === 'document') {

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -32,7 +32,8 @@ const crawlSitemap = async (
   needsReviewItems,
   fileTypes,
   blacklistedPatterns,
-  includeScreenshots
+  includeScreenshots,
+  extraHTTPHeaders
 ) => {
 
    // Boolean to omit axe scan for basic auth URL
@@ -105,7 +106,7 @@ const crawlSitemap = async (
       ],
     },
     requestList,
-    preNavigationHooks,
+    preNavigationHooks: preNavigationHooks(extraHTTPHeaders),
     requestHandler: async ({ page, request, response, sendRequest }) => {
       const actualUrl = request.loadedUrl || request.url;
 

--- a/crawlers/custom/utils.js
+++ b/crawlers/custom/utils.js
@@ -319,7 +319,30 @@ export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
 
         shadowRoot.appendChild(menu);
 
-        document.body.appendChild(shadowHost);
+        let currentNode = document.body
+        if (document.body) {
+          // The <body> element exists
+          if ( document.body.nodeName.toLowerCase() === 'frameset') {
+              // if currentNode is a <frameset>
+              // Move the variable outside the frameset then appendChild the component
+              while (currentNode.nodeName.toLowerCase()=== 'frameset' ) {
+                currentNode = currentNode.parentElement
+              }
+              currentNode.appendChild(shadowHost);
+            } else {
+              // currentNode is a <body>
+              currentNode.appendChild(shadowHost);
+            }
+        } else if (document.head) {
+          // The <head> element exists
+          // Append the variable below the head
+          head.insertAdjacentElement('afterend', shadowHost);
+        } else {
+          // Neither <body> nor <head> nor <html> exists
+          // Append the variable to the document
+          document.documentElement.appendChild(shadowHost);
+        }
+
       },
       { menuPos, MENU_POSITION, urlsCrawled },
     )


### PR DESCRIPTION
This PR adds a flag in CLI to accept headers such as cookie values for website crawler to scan authenticated sites <!-- A brief description of what your PR does -->
- Script the login and extract headers / cookies
- Implement the browser session with cookies / headers

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
