### PR TITLE
feat/js off message

### DIFF
--- a/static/ejs/partials/main.ejs
+++ b/static/ejs/partials/main.ejs
@@ -1,43 +1,39 @@
 <div class="d-flex flex-grow-1 align-items-stretch">
   <!-- main.ejs -->
-  <%- include("components/pagesScannedModal") %>
-  <%- include("components/screenshotLightbox") %>
+  <%- include("components/pagesScannedModal") %> <%- include("components/screenshotLightbox") %>
   <main class="d-flex flex-grow-1">
     <%- include("components/scanAbout") %>
     <!-- wcag compliance + top 5 -->
     <section class="w-100">
-
       <div class="compliance-summary">
         <div class="col card"><%- include("components/wcagCompliance") %></div>
         <div class="col card"><%- include("components/topFive") %></div>
       </div>
       <hr class="my-4 mx-3" />
+      <!-- jsOffMessage -->
+      <p id="jsOffMessage" class="mx-3">
+        Please open this file in a browser to experience the report's full functionality.
+      </p>
+      <div id="jsOn" class="d-none">
         <!-- Search Feat Input -->
-        <div id= "searchGroup" class="row m-0 px-3">
-          <%- include("components/reportSearch") %>
-        </div>
+        <div id="searchGroup" class="row m-0 px-3"><%- include("components/reportSearch") %></div>
         <!-- Button Category Selector -->
         <%- include("components/categorySelector") %>
 
-      <!-- Dropdown Category Selector -->
-      <%- include("components/categorySelectorDropdown") %>
-      <ul id="categorySummary" class="unbulleted-list px-3 py-4 mb-3 flex-grow-1">
-        <!-- dynamically generated section from scripts/categorySummary -->
-        <%# dynamically generated section from scripts/categorySummary %>
-      </ul>
-      <%- include("components/ruleOffcanvas") %> 
-      <p id="containsAISuggestions" class="d-none">
-        Tooltip: Contains AI suggestions.
-      </p>
-      <p id="mustFixAriaDescription" class="d-none">
-        Tooltip: <%= items.mustFix.description %>
-      </p>
-      <p id="goodToFixAriaDescription" class="d-none">
-        Tooltip: <%= items.goodToFix.description %>
-      </p>
-      <p id="passedAriaDescription" class="d-none">
-        Tooltip: <%= items.passed.description %>
-      </p>
+        <!-- Dropdown Category Selector -->
+        <%- include("components/categorySelectorDropdown") %>
+        <ul id="categorySummary" class="unbulleted-list px-3 py-4 mb-3 flex-grow-1">
+          <!-- dynamically generated section from scripts/categorySummary -->
+          <%# dynamically generated section from scripts/categorySummary %>
+        </ul>
+        <%- include("components/ruleOffcanvas") %>
+        <p id="containsAISuggestions" class="d-none">Tooltip: Contains AI suggestions.</p>
+        <p id="mustFixAriaDescription" class="d-none">Tooltip: <%= items.mustFix.description %></p>
+        <p id="goodToFixAriaDescription" class="d-none">
+          Tooltip: <%= items.goodToFix.description %>
+        </p>
+        <p id="passedAriaDescription" class="d-none">Tooltip: <%= items.passed.description %></p>
+      </div>
     </section>
   </main>
 </div>

--- a/static/ejs/report.ejs
+++ b/static/ejs/report.ejs
@@ -54,5 +54,10 @@
       }
       document.addEventListener('DOMContentLoaded', initTooltips);
     </script>
+    <!-- Checks if js runs -->
+    <script>
+      document.getElementById('jsOn').classList.remove('d-none');
+      document.getElementById('jsOffMessage').classList.add('d-none');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a functionality that shows jsOffMessage to direct users to open the report on a browser if they are opening the report on a non-js-enabled platform.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
