### PR TITLE
Improv/mass scanner wcag violations

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -490,6 +490,7 @@ export const generateArtifacts = async (
       "endTime": formatDateTimeForMassScanner(scanDetails? getFormattedTime(scanDetails.endTime):getFormattedTime()),
       "pagesScanned": allIssues.pagesScanned.length,
       "wcagPassPercentage": allIssues.wcagPassPercentage,
+      "wcagViolations": allIssues.wcagViolations,
       "critical": axeImpactCount.critical,
       "serious": axeImpactCount.serious,
       "moderate": axeImpactCount.moderate,

--- a/utils.js
+++ b/utils.js
@@ -277,4 +277,14 @@ export const randomThreeDigitNumberString = () => {
   return String(threeDigitNumber);
 }
 
-
+export const isFollowStrategy = (link1, link2, rule) =>{
+  if (rule === "same-domain"){
+    const link1Domain = link1.split('/')[2].split('.').slice(-2).join('.');
+    const link2Domain = link2.split('/')[2].split('.').slice(-2).join('.'); 
+    return link1Domain === link2Domain;
+  } else {
+    const parsedLink1 = new URL(link1);
+    const parsedLink2 = new URL(link2);
+    return parsedLink1.hostname === parsedLink2.hostname;
+  }
+}


### PR DESCRIPTION
## Bug Fix:
  -  Crawl Domain: handle redirects that do not follow strategy (same-domain/same-hostname). - Placed the check above runAxeScript so no time will be wasted scanning if redirect is not following strategy.

## Changes for Mass Scanner:
  - passed wcag violation data for mass scanner.

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
