### PR TITLE
Adds Scan Summary in JSON format when running process spawn or cli mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -418,12 +418,14 @@ scanInit(options).then(async storagePath => {
         );
       }
 
-      if (process.env.PURPLE_A11Y_VERBOSE && process.env.REPORT_BREAKDOWN != '1') {
+      if (process.send && process.env.PURPLE_A11Y_VERBOSE && process.env.REPORT_BREAKDOWN != '1') {
         let zipFileNameMessage = {
           type: 'zipFileName',
           payload: `${constants.cliZipFileName}`
         }
+
         process.send(JSON.stringify(zipFileNameMessage));
+       
       }
       
 

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -537,7 +537,6 @@ export const generateArtifacts = async (
       
     } catch (error) {
       console.log('Scan Data:',scanData);
-      console.log('Scan Summary Message :',scanSummaryMessage);
 }
   }
 

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -536,7 +536,7 @@ export const generateArtifacts = async (
       process.send(JSON.stringify(scanSummaryMessage));
       
     } catch (error) {
-      console.log('Scan Data:',scanData);
+      console.log('Scan Summary: ',scanData);
 }
   }
 

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -531,8 +531,14 @@ export const generateArtifacts = async (
       ]
     }
 
-    process.send(JSON.stringify(scanDataMessage));
-    process.send(JSON.stringify(scanSummaryMessage));
+    try {
+      process.send(JSON.stringify(scanDataMessage));
+      process.send(JSON.stringify(scanSummaryMessage));
+      
+    } catch (error) {
+      console.log('Scan Data:',scanData);
+      console.log('Scan Summary Message :',scanSummaryMessage);
+}
   }
 
   await writeResults(allIssues, storagePath);


### PR DESCRIPTION
Adds Scan Summary in JSON format when running in process spawn or cli mode

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
