### PR TITLE
Handle improperly encoded URIs and env for storage

### DIFF
--- a/constants/common.js
+++ b/constants/common.js
@@ -706,7 +706,7 @@ export const getLinksFromSitemap = async (
   const addToUrlList = url => {
     if (!url) return;
     if (isDisallowedInRobotsTxt(url)) return; 
-    const request = new Request({ url });
+    const request = new Request({ url: encodeURI(url) });
     if (isUrlPdf(url)) {
       request.skipNavigation = true;
     }

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -80,7 +80,8 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
    * First time scan with original `url` containing credentials is strictly to authenticate for browser session
    * subsequent URLs are without credentials.
    */
-
+  
+  url = encodeURI(url);
   
   if (basicAuthRegex.test(url)) {
     isBasicAuth = true;
@@ -110,6 +111,7 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
           // playwright headless mode does not support navigation to pdf document
           req.skipNavigation = true;
         }
+        req.url = encodeURI(req.url)
         return req;
       },
     });
@@ -208,6 +210,7 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
             // playwright headless mode does not support navigation to pdf document
             req.skipNavigation = true;
           }
+          req.url = encodeURI(req.url)
           return req;
         },
       })

--- a/crawlers/crawlSitemap.js
+++ b/crawlers/crawlSitemap.js
@@ -72,17 +72,19 @@ const crawlSitemap = async (
    * subsequent URLs are without credentials.
    * basicAuthPage is set to -1 for basic auth URL to ensure it is not counted towards maxRequestsPerCrawl
   */
- 
- if (basicAuthRegex.test(sitemapUrl)) {
-   isBasicAuth = true;
-   // request to basic auth URL to authenticate for browser session
-   finalLinks.push(new Request({ url: sitemapUrl, uniqueKey: `auth:${sitemapUrl}` }));
-   const finalUrl = `${sitemapUrl.split('://')[0]}://${sitemapUrl.split('@')[1]}`;
-   
-   // obtain base URL without credentials so that subsequent URLs within the same domain can be scanned
-   finalLinks.push(new Request({ url: finalUrl }));
-   basicAuthPage = -2;
-  } 
+
+  sitemapUrl = encodeURI(sitemapUrl)
+    
+  if (basicAuthRegex.test(sitemapUrl)) {
+    isBasicAuth = true;
+    // request to basic auth URL to authenticate for browser session
+    finalLinks.push(new Request({ url: sitemapUrl, uniqueKey: `auth:${sitemapUrl}` }));
+    const finalUrl = `${sitemapUrl.split('://')[0]}://${sitemapUrl.split('@')[1]}`;
+    
+    // obtain base URL without credentials so that subsequent URLs within the same domain can be scanned
+    finalLinks.push(new Request({ url: finalUrl }));
+    basicAuthPage = -2;
+    } 
   
   
   let pdfDownloads = [];

--- a/utils.js
+++ b/utils.js
@@ -25,7 +25,7 @@ export const isWhitelistedContentType = contentType => {
 };
 
 export const getStoragePath = randomToken => {
-  if (process.env.PURPLE_A11Y_VERBOSE){
+  if (process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH){
     return `${process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH}/${randomToken}`
   }
   if (constants.exportDirectory === process.cwd()) {


### PR DESCRIPTION
This PR adds...

 - Encode uri at all scan modes to prevent playwright regExp error at globToRegex function
 - Allow user to specify `PURPLE_A11Y_VERBOSE_STORAGE_PATH` environment variable to set storage path for results

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
