### PR TITLE
delete intermediate folder for desktop cancel function

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -364,6 +364,16 @@ const scanInit = async argvs => {
 
   const data = await prepareData(argvs);
 
+  if (process.env.RUNNING_FROM_PH_GUI){
+    let randomTokenMessage = {
+      type: 'randomToken',
+      payload: `${data.randomToken}`
+    }
+    if (process.send){
+    process.send(JSON.stringify(randomTokenMessage));
+  }
+  }
+
   setHeadlessMode(data.browser, data.isHeadless);
 
   const screenToScan = getScreenToScan(argvs.deviceChosen, argvs.customDevice, argvs.viewportWidth);

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -263,7 +263,7 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
         };
       }
 
-      if (category !== 'passed') {
+      if (category !== 'passed' && category!== 'needsReview') {
         conformance
           .filter(c => /wcag[0-9]{3,4}/.test(c))
           .forEach(c => allIssues.wcagViolations.add(c));
@@ -490,7 +490,6 @@ export const generateArtifacts = async (
       "endTime": formatDateTimeForMassScanner(scanDetails? getFormattedTime(scanDetails.endTime):getFormattedTime()),
       "pagesScanned": allIssues.pagesScanned.length,
       "wcagPassPercentage": allIssues.wcagPassPercentage,
-      "wcagViolations": allIssues.wcagViolations,
       "critical": axeImpactCount.critical,
       "serious": axeImpactCount.serious,
       "moderate": axeImpactCount.moderate,
@@ -531,13 +530,12 @@ export const generateArtifacts = async (
       ]
     }
 
-    try {
+    if (process.send){
       process.send(JSON.stringify(scanDataMessage));
       process.send(JSON.stringify(scanSummaryMessage));
-      
-    } catch (error) {
+    } else {
       console.log('Scan Summary: ',scanData);
-}
+    }
   }
 
   await writeResults(allIssues, storagePath);


### PR DESCRIPTION
 - Sending over name of intermediate folder to desktop via message to parent process, so that intermediate folders can be deleted from desktop.
 - Needs Review no longer considered when tabulating wcag violations.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
