### PR TITLE
improv/zipFilename: Fix cli zip filename contains .something issue

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -413,7 +413,7 @@ scanInit(options).then(async storagePath => {
     constants.cliZipFileName = options.zip;
     
     if (!options.zip.endsWith('.zip')){
-    options.zip += '.zip';
+      options.zip += '.zip';
     }
   }
 

--- a/cli.js
+++ b/cli.js
@@ -409,7 +409,7 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async storagePath => {
   // Take option if set
-  if (typeof options.zip === 'string' {
+  if (typeof options.zip === 'string') {
     constants.cliZipFileName = options.zip;
     
     if (!options.zip.endsWith('.zip')){

--- a/cli.js
+++ b/cli.js
@@ -409,13 +409,13 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async storagePath => {
   // Take option if set
-  if (typeof options.zip === 'string' && !options.zip.endsWith('.zip')) {
-    options.zip += '.zip';
-  }
-
-  if(typeof options.zip === 'string'){
+  if (typeof options.zip === 'string' {
     constants.cliZipFileName = options.zip;
-  } 
+    
+    if (!options.zip.endsWith('.zip')){
+    options.zip += '.zip';
+    }
+  }
 
   await fs
     .ensureDir(storagePath)

--- a/cli.js
+++ b/cli.js
@@ -409,9 +409,13 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async storagePath => {
   // Take option if set
-  if (typeof options.zip === 'string') {
-    constants.cliZipFileName = options.zip;
+  if (typeof options.zip === 'string' && !options.zip.endsWith('.zip')) {
+    options.zip += '.zip';
   }
+
+  if(typeof options.zip === 'string'){
+    constants.cliZipFileName = options.zip;
+  } 
 
   await fs
     .ensureDir(storagePath)


### PR DESCRIPTION
Fix websites with .sg to have .zip as well

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
