### PR TITLE
Resolve zip filename contains dot and check for exclusions.txt at redirects on scan start

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -413,7 +413,7 @@ scanInit(options).then(async storagePath => {
     constants.cliZipFileName = options.zip;
     
     if (!options.zip.endsWith('.zip')){
-      options.zip += '.zip';
+      constants.cliZipFileName += '.zip';
     }
   }
 

--- a/cli.js
+++ b/cli.js
@@ -413,7 +413,7 @@ scanInit(options).then(async storagePath => {
     constants.cliZipFileName = options.zip;
     
     if (!options.zip.endsWith('.zip')){
-    options.zip += '.zip';
+      options.zip += '.zip';
     }
   }
 

--- a/cli.js
+++ b/cli.js
@@ -409,7 +409,7 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async storagePath => {
   // Take option if set
-  if (typeof options.zip === 'string' {
+  if (typeof options.zip === 'string') {
     constants.cliZipFileName = options.zip;
     
     if (!options.zip.endsWith('.zip')){

--- a/cli.js
+++ b/cli.js
@@ -409,13 +409,13 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async storagePath => {
   // Take option if set
-  if (typeof options.zip === 'string' && !options.zip.endsWith('.zip')) {
-    options.zip += '.zip';
-  }
-
-  if(typeof options.zip === 'string'){
+  if (typeof options.zip === 'string' {
     constants.cliZipFileName = options.zip;
-  } 
+    
+    if (!options.zip.endsWith('.zip')){
+    options.zip += '.zip';
+    }
+  }
 
   await fs
     .ensureDir(storagePath)

--- a/cli.js
+++ b/cli.js
@@ -409,9 +409,13 @@ const scanInit = async argvs => {
 
 scanInit(options).then(async storagePath => {
   // Take option if set
-  if (typeof options.zip === 'string') {
-    constants.cliZipFileName = options.zip;
+  if (typeof options.zip === 'string' && !options.zip.endsWith('.zip')) {
+    options.zip += '.zip';
   }
+
+  if(typeof options.zip === 'string'){
+    constants.cliZipFileName = options.zip;
+  } 
 
   await fs
     .ensureDir(storagePath)

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -18,7 +18,8 @@ import {
   isBlacklistedFileExtensions,
   isSkippedUrl,
   isDisallowedInRobotsTxt,
-  getUrlsFromRobotsTxt
+  getUrlsFromRobotsTxt,
+  getBlackListedPatterns,
 } from '../constants/common.js';
 import { areLinksEqual, isFollowStrategy } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -46,30 +47,30 @@ const crawlDomain = async (
   urlsCrawledFromIntelligent = null, //optional
 
 ) => {
-let dataset;
-let urlsCrawled
-let requestQueue;
+  let dataset;
+  let urlsCrawled
+  let requestQueue;
 
-if (fromCrawlIntelligentSitemap){
-  dataset=datasetFromIntelligent;
-  urlsCrawled = urlsCrawledFromIntelligent;
-} else {
-  ({ dataset } = await createCrawleeSubFolders(randomToken));
-  urlsCrawled = { ...constants.urlsCrawledObj };
-}
+  if (fromCrawlIntelligentSitemap) {
+    dataset = datasetFromIntelligent;
+    urlsCrawled = urlsCrawledFromIntelligent;
+  } else {
+    ({ dataset } = await createCrawleeSubFolders(randomToken));
+    urlsCrawled = { ...constants.urlsCrawledObj };
+  }
 
-({ requestQueue } = await createCrawleeSubFolders(randomToken));
+  ({ requestQueue } = await createCrawleeSubFolders(randomToken));
 
-if (!fs.existsSync(randomToken)) {
-  fs.mkdirSync(randomToken);
-}
+  if (!fs.existsSync(randomToken)) {
+    fs.mkdirSync(randomToken);
+  }
 
-let pdfDownloads = [];
-let uuidToPdfMapping = {};
-const isScanHtml = ['all', 'html-only'].includes(fileTypes);
-const isScanPdfs = ['all', 'pdf-only'].includes(fileTypes);
-const { maxConcurrency } = constants;
-const { playwrightDeviceDetailsObject } = viewportSettings;
+  let pdfDownloads = [];
+  let uuidToPdfMapping = {};
+  const isScanHtml = ['all', 'html-only'].includes(fileTypes);
+  const isScanPdfs = ['all', 'pdf-only'].includes(fileTypes);
+  const { maxConcurrency } = constants;
+  const { playwrightDeviceDetailsObject } = viewportSettings;
   let finalUrl;
   // Boolean to omit axe scan for basic auth URL
   let isBasicAuth = false;
@@ -80,9 +81,9 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
    * First time scan with original `url` containing credentials is strictly to authenticate for browser session
    * subsequent URLs are without credentials.
    */
-  
+
   url = encodeURI(url);
-  
+
   if (basicAuthRegex.test(url)) {
     isBasicAuth = true;
     // request to basic auth URL to authenticate for browser session
@@ -103,9 +104,9 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
       strategy,
       requestQueue,
       transformRequestFunction(req) {
-        if (urlsCrawled.scanned.some(item => item.url === req.url)){
+        if (urlsCrawled.scanned.some(item => item.url === req.url)) {
           req.skipNavigation = true;
-        } 
+        }
         if (isDisallowedInRobotsTxt(req.url)) return null;
         if (isUrlPdf(req.url)) {
           // playwright headless mode does not support navigation to pdf document
@@ -201,9 +202,9 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
         // handle onclick
         selector: ':not(a):is([role="link"], button[onclick])',
         transformRequestFunction(req) {
-          if (urlsCrawled.scanned.some(item => item.url === req.url)){
+          if (urlsCrawled.scanned.some(item => item.url === req.url)) {
             req.skipNavigation = true;
-          }  
+          }
           if (isDisallowedInRobotsTxt(req.url)) return null;
           req.url = req.url.replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');
           if (isUrlPdf(req.url) || urlsCrawled.scanned.some(item => item.url === req.url)) {
@@ -251,15 +252,38 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
       enqueueLinks,
       enqueueLinksByClickingElements,
     }) => {
+
+      const blacklistedPatterns = getBlackListedPatterns();
+
+      function isExcluded(url) {
+        // Check if any pattern matches the URL.
+        return blacklistedPatterns.some(pattern => {
+          // If using simple substring matching:
+          return url.includes(pattern);
+        });
+      }
+
       // loadedUrl is the URL after redirects
       const actualUrl = request.loadedUrl || request.url;
+
+      if (isExcluded(actualUrl)) {
+        guiInfoLog(guiInfoStatusTypes.SKIPPED, {
+          numScanned: urlsCrawled.scanned.length,
+          urlScanned: actualUrl,
+        });
+        urlsCrawled.excluded.push(actualUrl); 
+        return; 
+      }
+
       if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) {
         crawler.autoscaledPool.abort();
         return;
       }
 
+
+
       // if URL has already been scanned
-      if (urlsCrawled.scanned.some(item => item.url === request.url)){
+      if (urlsCrawled.scanned.some(item => item.url === request.url)) {
         await enqueueProcess(page, enqueueLinks, enqueueLinksByClickingElements);
         return;
       }
@@ -344,7 +368,7 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
           if (isScanHtml) {
             // For deduplication, if the URL is redirected, we want to store the original URL and the redirected URL (actualUrl)
             const isRedirected = !areLinksEqual(request.loadedUrl, request.url);
-            
+
             // check if redirected link is following strategy (same-domain/same-hostname)
             const isLoadedUrlFollowStrategy = isFollowStrategy(request.loadedUrl, url, strategy);
             if (isRedirected && !isLoadedUrlFollowStrategy) {
@@ -376,7 +400,7 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
                   numScanned: urlsCrawled.scanned.length,
                   urlScanned: request.url,
                 });
-                
+
                 urlsCrawled.scanned.push({
                   url: request.url,
                   pageTitle: results.pageTitle,
@@ -454,7 +478,7 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
 
 
 
- 
+
   if (pdfDownloads.length > 0) {
     // wait for pdf downloads to complete
     await Promise.all(pdfDownloads);
@@ -476,7 +500,7 @@ const { playwrightDeviceDetailsObject } = viewportSettings;
     await Promise.all(pdfResults.map(result => dataset.pushData(result)));
   }
 
-  if (!fromCrawlIntelligentSitemap){
+  if (!fromCrawlIntelligentSitemap) {
     guiInfoLog(guiInfoStatusTypes.COMPLETED);
   }
 


### PR DESCRIPTION
- Minor changes to fix websites with dot (.) to have .zip extension
- Added check against a exclusion.txt even for the first page
- Added check against websites that direct to websites in exclusion.txt

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions