### PR TITLE
Improvement for plural issues and start time on report

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -59,7 +59,7 @@ const combineRun = async (details, deviceToScan) => {
   }
 
   const scanDetails = {
-    startTime: new Date().getTime(),
+    startTime: new Date(),
     crawlType: type,
     requestUrl: finalUrl,
   };
@@ -144,7 +144,7 @@ const combineRun = async (details, deviceToScan) => {
       process.exit(1);
   }
 
-  scanDetails.endTime = new Date().getTime();
+  scanDetails.endTime = new Date();
   scanDetails.urlsCrawled = urlsCrawled;
   await createDetailsAndLogs(scanDetails, randomToken);
   if (scanDetails.urlsCrawled.scanned.length > 0) {

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -389,8 +389,8 @@ export const generateArtifacts = async (
   const storagePath = getStoragePath(randomToken);
   const directory = `${storagePath}/${constants.allIssueFileName}`;
 
-  const formatAboutStartTime = (dateString) => {
-    const utcStartTimeDate = new Date(dateString)
+  const formatAboutStartTime = dateString => {
+    const utcStartTimeDate = new Date(dateString);
     const formattedStartTime = utcStartTimeDate.toLocaleTimeString('en-GB', {
       year: 'numeric',
       month: 'short',
@@ -398,16 +398,22 @@ export const generateArtifacts = async (
       hour12: false,
       hour: 'numeric',
       minute: '2-digit',
-      timeZoneName: 'longGeneric',
+      timeZoneName: 'shortGeneric',
     });
 
-    //adding a breakline between the time and timezone so it looks neater on report
-    const lastTimeIndex = formattedStartTime.lastIndexOf(':');
-    const timePart = formattedStartTime.slice(0, lastTimeIndex + 3);
-    const timeZonePart = formattedStartTime.slice(lastTimeIndex + 3);
-    const htmlFormattedStartTime = `${timePart} \n${timeZonePart}`;
+    const timezoneAbbreviation = new Intl.DateTimeFormat('en', {
+      timeZoneName: 'shortOffset',
+    })
+      .formatToParts(utcStartTimeDate)
+      .find(part => part.type === 'timeZoneName').value;
 
-    return htmlFormattedStartTime
+    //adding a breakline between the time and timezone so it looks neater on report
+    const timeColonIndex = formattedStartTime.lastIndexOf(':');
+    const timePart = formattedStartTime.slice(0, timeColonIndex + 3);
+    const timeZonePart = formattedStartTime.slice(timeColonIndex + 4);
+    const htmlFormattedStartTime = `${timePart}<br>${timeZonePart} ${timezoneAbbreviation}`;
+
+    return htmlFormattedStartTime;
   };
 
   const isCustomFlow = scanType === constants.scannerTypes.custom;

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -388,6 +388,28 @@ export const generateArtifacts = async (
   const phAppVersion = getVersion();
   const storagePath = getStoragePath(randomToken);
   const directory = `${storagePath}/${constants.allIssueFileName}`;
+
+  const formatAboutStartTime = (dateString) => {
+    const utcStartTimeDate = new Date(dateString)
+    const formattedStartTime = utcStartTimeDate.toLocaleTimeString('en-GB', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour12: false,
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'longGeneric',
+    });
+
+    //adding a breakline between the time and timezone so it looks neater on report
+    const lastTimeIndex = formattedStartTime.lastIndexOf(':');
+    const timePart = formattedStartTime.slice(0, lastTimeIndex + 3);
+    const timeZonePart = formattedStartTime.slice(lastTimeIndex + 3);
+    const htmlFormattedStartTime = `${timePart} \n${timeZonePart}`;
+
+    return htmlFormattedStartTime
+  };
+
   const isCustomFlow = scanType === constants.scannerTypes.custom;
   const allIssues = {
     storagePath,
@@ -395,9 +417,10 @@ export const generateArtifacts = async (
       htmlETL: purpleAiHtmlETL,
       rules: purpleAiRules,
     },
-    startTime: scanDetails.startTime? getFormattedTime(scanDetails.startTime) : getFormattedTime(),
+    startTime: scanDetails.startTime? scanDetails.startTime : new Date(),
     urlScanned,
     scanType,
+    formatAboutStartTime,
     isCustomFlow,
     viewport,
     pagesScanned,
@@ -438,10 +461,10 @@ export const generateArtifacts = async (
   printMessage([
     'Scan Summary',
     '',
-    `Must Fix: ${allIssues.items.mustFix.rules.length} issues / ${allIssues.items.mustFix.totalItems} occurrences`,
-    `Good to Fix: ${allIssues.items.goodToFix.rules.length} issues / ${allIssues.items.goodToFix.totalItems} occurrences`,
-    `Needs Review: ${allIssues.items.needsReview.rules.length} issues / ${allIssues.items.needsReview.totalItems} occurrences`,
-    `Passed: ${allIssues.items.passed.totalItems} occurrences`,
+    `Must Fix: ${allIssues.items.mustFix.rules.length} ${allIssues.items.mustFix.rules.length === 1 ? 'issue' : 'issues'} / ${allIssues.items.mustFix.totalItems} ${allIssues.items.mustFix.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
+    `Good to Fix: ${allIssues.items.goodToFix.rules.length} ${allIssues.items.goodToFix.rules.length === 1 ? 'issue' : 'issues'} / ${allIssues.items.goodToFix.totalItems} ${allIssues.items.goodToFix.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
+    `Needs Review: ${allIssues.items.needsReview.rules.length} ${allIssues.items.needsReview.rules.length === 1 ? 'issue' : 'issues'} / ${allIssues.items.needsReview.totalItems} ${allIssues.items.needsReview.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
+    `Passed: ${allIssues.items.passed.totalItems} ${allIssues.items.passed.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
   ]);
 
   // move screenshots folder to report folders
@@ -487,7 +510,7 @@ export const generateArtifacts = async (
     let scanData = {
       "url": allIssues.urlScanned,
       "startTime": formatDateTimeForMassScanner(allIssues.startTime),
-      "endTime": formatDateTimeForMassScanner(scanDetails? getFormattedTime(scanDetails.endTime):getFormattedTime()),
+      "endTime": formatDateTimeForMassScanner(scanDetails? scanDetails.endTime: new Date()),
       "pagesScanned": allIssues.pagesScanned.length,
       "wcagPassPercentage": allIssues.wcagPassPercentage,
       "critical": axeImpactCount.critical,
@@ -522,10 +545,10 @@ export const generateArtifacts = async (
     let scanSummaryMessage = {
       type: 'scanSummary',
       payload: [
-        `Must Fix: ${allIssues.items.mustFix.rules.length} issues / ${allIssues.items.mustFix.totalItems} occurrences`,
-        `Good to Fix: ${allIssues.items.goodToFix.rules.length} issues / ${allIssues.items.goodToFix.totalItems} occurrences`,
-        `Needs Review: ${allIssues.items.needsReview.rules.length} issues / ${allIssues.items.needsReview.totalItems} occurrences`,
-        `Passed: ${allIssues.items.passed.totalItems} occurrences`,
+        `Must Fix: ${allIssues.items.mustFix.rules.length} ${allIssues.items.mustFix.rules.length === 1 ? 'issue' : 'issues'} / ${allIssues.items.mustFix.totalItems} ${allIssues.items.mustFix.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
+        `Good to Fix: ${allIssues.items.goodToFix.rules.length} ${allIssues.items.goodToFix.rules.length === 1 ? 'issue' : 'issues'} / ${allIssues.items.goodToFix.totalItems} ${allIssues.items.goodToFix.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
+        `Needs Review: ${allIssues.items.needsReview.rules.length} ${allIssues.items.needsReview.rules.length === 1 ? 'issue' : 'issues'} / ${allIssues.items.needsReview.totalItems} ${allIssues.items.needsReview.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
+        `Passed: ${allIssues.items.passed.totalItems} ${allIssues.items.passed.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
         `Results directory: ${storagePath}`,
       ]
     }

--- a/npmIndex.js
+++ b/npmIndex.js
@@ -49,7 +49,7 @@ export const init = async (
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
   const scanDetails = {
-    startTime: new Date().getTime(),
+    startTime: new Date(),
     crawlType: 'Custom',
     requestUrl: entryUrl,
     urlsCrawled: { ...constants.urlsCrawledObj },
@@ -167,7 +167,7 @@ export const init = async (
     throwErrorIfTerminated();
     console.log('Stopping Purple A11y');
     isInstanceTerminated = true;
-    scanDetails.endTime = new Date().getTime();
+    scanDetails.endTime = new Date();
     scanDetails.urlsCrawled = urlsCrawled;
 
     if (urlsCrawled.scanned.length === 0) {

--- a/playwrightAxeGenerator.js
+++ b/playwrightAxeGenerator.js
@@ -81,7 +81,7 @@ await cleanUp(${formatScriptStringVar(randomToken)});
 process.env.CRAWLEE_STORAGE_DIR = ${formatScriptStringVar(randomToken)};
 
 const scanDetails = {
-    startTime: new Date().getTime(),
+    startTime: new Date(),
     crawlType: 'Custom Flow',
     requestUrl: ${formatScriptStringVar(data.url)},
 };
@@ -422,7 +422,7 @@ const waitForCaptcha = async (page, captchaLocator) => {
         process.exit(1);
       }
         })().then(async (urlsCrawled) => {
-            scanDetails.endTime = new Date().getTime();
+            scanDetails.endTime = new Date();
             scanDetails.urlsCrawled = urlsCrawled;
             await createDetailsAndLogs(scanDetails, ${formatScriptStringVar(randomToken)});
             await createAndUpdateResultsFolders(${formatScriptStringVar(randomToken)});

--- a/static/ejs/partials/components/categorySelector.ejs
+++ b/static/ejs/partials/components/categorySelector.ejs
@@ -51,11 +51,11 @@
           </div>
           <span id="<%= category %>ItemsInformation" class="category-information">
             <% if (category !== 'passed' && items[category].totalItems !== 0) { %> 
-              <%= items[category].rules.length %> issues / <%= items[category].totalItems %> occurrences
+              <%= items[category].rules.length %> <%= items[category].rules.length === 1 ? 'issue' : 'issues' %> / <%= items[category].totalItems %> <%= items[category].totalItems === 1 ? 'occurrence' : 'occurrences' %>
             <% } else if (category !== 'passed' && items[category].totalItems === 0) { %>
               0 issues
             <% } else { %>
-              <%= items[category].totalItems %> occurrences
+              <%= items[category].totalItems %> <%= items[category].totalItems === 1 ? 'occurrence' : 'occurrences' %>
             <% } %>
           </span>
         </button>

--- a/static/ejs/partials/components/categorySelectorDropdown.ejs
+++ b/static/ejs/partials/components/categorySelectorDropdown.ejs
@@ -45,11 +45,11 @@
         </span>
         <span id="<%= category %>ItemsInformation" class="category-information">
             <% if (category !== 'passed' && items[category].totalItems !== 0) { %> 
-              (<%= items[category].rules.length %> issues) 
+              (<%= items[category].rules.length %> <%= items[category].rules.length === 1 ? 'issue' : 'issues' %>) 
             <% } else if (category !== 'passed' && items[category].totalItems === 0) { %>
               (0 issues)
             <% } else { %>
-              (<%= items[category].totalItems %> occurrences)
+              (<%= items[category].totalItems %> <%= items[category].totalItems === 1 ? 'occurrence' : 'occurrences' %>)
             <% } %>
           </span>
         </li>

--- a/static/ejs/partials/components/scanAbout.ejs
+++ b/static/ejs/partials/components/scanAbout.ejs
@@ -17,7 +17,7 @@
           fill="#CED4DA"
         />
       </svg>
-      <span><%= startTime %></span>
+      <span id="aboutStartTime"><%- unescape(formatAboutStartTime(startTime)) %></span>
     </li>
     <li>
       <svg
@@ -141,7 +141,7 @@
         id="pagesScannedModalToggle"
         data-bs-toggle="modal"
         data-bs-target="#pagesScannedModal"
-      ><%= isCustomFlow ? customFlowLabel + ' (' + totalPagesScanned + ' pages)' : scanType + ' crawl' + ' (' + totalPagesScanned + ' pages)'%>
+        ><%= isCustomFlow ? customFlowLabel + ' (' + totalPagesScanned + ' ' + (totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanType + ' crawl' + ' (' + totalPagesScanned + ' ' + (totalPagesScanned === 1 ? 'page' : 'pages') + ')'%>
       <% if (totalPagesNotScanned > 0) { %>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
           <path d="M12 19.875C9.91142 19.875 7.90838 19.0453 6.43153 17.5685C4.95468 16.0916 4.125 14.0886 4.125 12C4.125 9.91142 4.95468 7.90838 6.43153 6.43153C7.90838 4.95468 9.91142 4.125 12 4.125C14.0886 4.125 16.0916 4.95468 17.5685 6.43153C19.0453 7.90838 19.875 9.91142 19.875 12C19.875 14.0886 19.0453 16.0916 17.5685 17.5685C16.0916 19.0453 14.0886 19.875 12 19.875ZM12 21C14.3869 21 16.6761 20.0518 18.364 18.364C20.0518 16.6761 21 14.3869 21 12C21 9.61305 20.0518 7.32387 18.364 5.63604C16.6761 3.94821 14.3869 3 12 3C9.61305 3 7.32387 3.94821 5.63604 5.63604C3.94821 7.32387 3 9.61305 3 12C3 14.3869 3.94821 16.6761 5.63604 18.364C7.32387 20.0518 9.61305 21 12 21Z" fill="#D7260F"/>
@@ -197,8 +197,8 @@
         </defs>
       </svg>
       <span>
-        <%= items.mustFix.totalItems + items.goodToFix.totalItems  %> occurrences failed,<br>
-        <%= items.passed.totalItems %> occurrences passed
+        <%= items.mustFix.totalItems + items.goodToFix.totalItems  %> <%= (items.mustFix.totalItems + items.goodToFix.totalItems === 1 ? 'occurrence' : 'occurrences') %> failed,<br>
+        <%= items.passed.totalItems %> <%= (items.passed.totalItems === 1 ? 'occurrence' : 'occurrences') %> passed
         <svg
           tabindex="-1"
           id="passedItemsTooltip"

--- a/static/ejs/partials/components/summaryScanAbout.ejs
+++ b/static/ejs/partials/components/summaryScanAbout.ejs
@@ -16,7 +16,7 @@
         fill="#CED4DA"
       />
     </svg>
-    <span><%= startTime %></span>
+    <span><%- unescape(formatAboutStartTime(startTime)) %></span>
   </li>
   <li class="svg-container" style="word-break: break-all;">
     <svg

--- a/static/ejs/partials/scripts/categorySummary.ejs
+++ b/static/ejs/partials/scripts/categorySummary.ejs
@@ -2,7 +2,7 @@
 <script>
   window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('mustFixSelector').click();
-    // document.getElementById('issueDescriptionsButton').click();
+    document.getElementById('issueDescriptionsButton').click();
     // document.getElementById('mustFixDropdownSelector').click();
   });
 
@@ -34,7 +34,7 @@
         handleSearch(category, searchVal, filteredItems);
       }
     } else {
-      resetIssueOccurrence(category, filteredItems);
+      resetIssueOccurrence(filteredItems);
     }
 
     const formatItemsCount = count => {

--- a/static/ejs/partials/scripts/reportSearch.ejs
+++ b/static/ejs/partials/scripts/reportSearch.ejs
@@ -179,25 +179,32 @@
     let totalItemsSum = rules.reduce((sum, rule) => sum + rule.totalItems, 0);
     filteredItems[category].totalItems = totalItemsSum;
     let updatedIssueOccurrence = '';
+
+    // Determine the correct singular/plural form for 'issue' and 'occurrence'
+    const issueLabel = filteredItems[category].rules.length === 1 ? 'issue' : 'issues';
+    const occurrenceLabel = filteredItems[category].totalItems === 1 ? 'occurrence' : 'occurrences';
+
     if (category !== 'passed' && filteredItems[category].totalItems !== 0) {
-      updatedIssueOccurrence = `<strong style="color: #0047FA;">${filteredItems[category].rules.length}</strong> issues / <strong style="color: #0047FA;">${filteredItems[category].totalItems}</strong> occurrences`;
+      updatedIssueOccurrence = `<strong style="color: #0047FA;">${filteredItems[category].rules.length}</strong> ${issueLabel} / <strong style="color: #0047FA;">${filteredItems[category].totalItems}</strong> ${occurrenceLabel}`;
     } else if (category !== 'passed' && filteredItems[category].totalItems === 0) {
       updatedIssueOccurrence = `<strong style="color: #0047FA;">0</strong> issues`;
     } else {
-      updatedIssueOccurrence = `<strong style="color: #0047FA;">${filteredItems[category].totalItems}</strong> occurrences`;
+      updatedIssueOccurrence = `<strong style="color: #0047FA;">${filteredItems[category].totalItems}</strong> ${occurrenceLabel}`;
     }
     if (category !== 'passed') document.getElementById(`${category}ItemsInformation`).innerHTML = updatedIssueOccurrence;
   }
 
-  function resetIssueOccurrence(category, filteredItems) {
+  function resetIssueOccurrence(filteredItems) {
     for (let category in filteredItems) {
+      const issueLabel = filteredItems[category].rules.length === 1 ? 'issue' : 'issues';
+      const occurrenceLabel = filteredItems[category].totalItems === 1 ? 'occurrence' : 'occurrences';
       let updatedIssueOccurrence = '';
       if (category !== 'passed' && filteredItems[category].totalItems !== 0) {
-        updatedIssueOccurrence = `${filteredItems[category].rules.length} issues / ${filteredItems[category].totalItems} occurrences`;
+        updatedIssueOccurrence = `${filteredItems[category].rules.length} ${issueLabel} / ${filteredItems[category].totalItems} ${occurrenceLabel}`;
       } else if (category !== 'passed' && filteredItems[category].totalItems === 0) {
         updatedIssueOccurrence = `0 issues`;
       } else {
-        updatedIssueOccurrence = `${filteredItems[category].totalItems} occurrences`;
+        updatedIssueOccurrence = `${filteredItems[category].totalItems} ${occurrenceLabel}`;
       }
       if (category !== 'passed') document.getElementById(`${category}ItemsInformation`).innerHTML = updatedIssueOccurrence;
     }

--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -122,11 +122,11 @@ category summary is clicked %>
         const element = createElementFromString(`
           <button aria-label="${getFormattedCategoryTitle(category)}, ${
           ruleInCategory.totalItems
-        } occurrences" class="category-selector ${category}">
+        } ${ruleInCategory.totalItems === 1 ? 'occurrence' : 'occurrences'}" class="category-selector ${category}">
             <span class="d-flex align-items-center category-name">${getFormattedCategoryTitle(
               category,
             )}</span>
-            <span class="category-information">${ruleInCategory.totalItems} occurrences</span>
+            <span class="category-information">${ruleInCategory.totalItems} ${ruleInCategory.totalItems === 1 ? 'occurrence' : 'occurrences'}</span>
           </button>
         `);
         element.addEventListener('click', event => {
@@ -186,7 +186,7 @@ category summary is clicked %>
             <div class="accordion-item">
               <div class="accordion-header" id="${accordionId}-title">
                 <button
-                  aria-label="Page ${index + 1}: ${page.pageTitle}, ${page.items.length} occurrences" class="accordion-button collapsed"
+                  aria-label="Page ${index + 1}: ${page.pageTitle}, ${page.items.length} ${page.items.length === 1 ? 'occurrence' : 'occurrences'}" class="accordion-button collapsed"
                   type="button"
                   data-bs-toggle="collapse"
                   data-bs-target="#${accordionId}-content"

--- a/static/ejs/report.ejs
+++ b/static/ejs/report.ejs
@@ -28,7 +28,9 @@
               ...items.passed
             },
           }
-        ) %>
+        ) %>;
+
+      const startTime = <%- JSON.stringify(startTime) %>
     </script>
   </head>
 
@@ -52,7 +54,37 @@
           return tooltip;
         });
       }
-      document.addEventListener('DOMContentLoaded', initTooltips);
+      
+      const initAboutStartTime = () => {
+          const formattedViewerLocalStartTime = formatAboutStartTime(startTime)
+          document.getElementById('aboutStartTime').innerHTML = formattedViewerLocalStartTime;
+        };
+
+        const formatAboutStartTime = (dateString) => {
+          const utcStartTimeDate = new Date(dateString)
+          const formattedStartTime = utcStartTimeDate.toLocaleTimeString('en-GB', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour12: false,
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'longGeneric',
+          });
+
+          //adding a breakline between the time and timezone so it looks neater on report
+          const lastTimeIndex = formattedStartTime.lastIndexOf(':');
+          const timePart = formattedStartTime.slice(0, lastTimeIndex + 3);
+          const timeZonePart = formattedStartTime.slice(lastTimeIndex + 3);
+          const htmlFormattedStartTime = `${timePart}<br>${timeZonePart}`;
+
+          return htmlFormattedStartTime
+        };
+
+      document.addEventListener('DOMContentLoaded', () => {
+        initTooltips();
+        initAboutStartTime();
+      });
     </script>
     <!-- Checks if js runs -->
     <script>

--- a/static/ejs/report.ejs
+++ b/static/ejs/report.ejs
@@ -54,32 +54,38 @@
           return tooltip;
         });
       }
-      
+
       const initAboutStartTime = () => {
-          const formattedViewerLocalStartTime = formatAboutStartTime(startTime)
-          document.getElementById('aboutStartTime').innerHTML = formattedViewerLocalStartTime;
-        };
+        const formattedViewerLocalStartTime = formatAboutStartTime(startTime);
+        document.getElementById('aboutStartTime').innerHTML = formattedViewerLocalStartTime;
+      };
 
-        const formatAboutStartTime = (dateString) => {
-          const utcStartTimeDate = new Date(dateString)
-          const formattedStartTime = utcStartTimeDate.toLocaleTimeString('en-GB', {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-            hour12: false,
-            hour: 'numeric',
-            minute: '2-digit',
-            timeZoneName: 'longGeneric',
-          });
+      const formatAboutStartTime = dateString => {
+        const utcStartTimeDate = new Date(dateString);
+        const formattedStartTime = utcStartTimeDate.toLocaleTimeString('en-GB', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour12: false,
+          hour: 'numeric',
+          minute: '2-digit',
+          timeZoneName: 'shortGeneric',
+        });
 
-          //adding a breakline between the time and timezone so it looks neater on report
-          const lastTimeIndex = formattedStartTime.lastIndexOf(':');
-          const timePart = formattedStartTime.slice(0, lastTimeIndex + 3);
-          const timeZonePart = formattedStartTime.slice(lastTimeIndex + 3);
-          const htmlFormattedStartTime = `${timePart}<br>${timeZonePart}`;
+        const timezoneAbbreviation = new Intl.DateTimeFormat('en', {
+          timeZoneName: 'shortOffset',
+        })
+          .formatToParts(utcStartTimeDate)
+          .find(part => part.type === 'timeZoneName').value;
 
-          return htmlFormattedStartTime
-        };
+        //adding a breakline between the time and timezone so it looks neater on report
+        const timeColonIndex = formattedStartTime.lastIndexOf(':');
+        const timePart = formattedStartTime.slice(0, timeColonIndex + 3);
+        const timeZonePart = formattedStartTime.slice(timeColonIndex + 4);
+        const htmlFormattedStartTime = `${timePart}<br>${timeZonePart} ${timezoneAbbreviation}`;
+
+        return htmlFormattedStartTime;
+      };
 
       document.addEventListener('DOMContentLoaded', () => {
         initTooltips();

--- a/utils.js
+++ b/utils.js
@@ -163,20 +163,20 @@ export const cleanUp = async pathToDelete => {
 //     hour12: true,
 //     hour: 'numeric',
 //     minute: '2-digit',
+//     timeZoneName: "longGeneric",
 //   });
 
 export const getWcagPassPercentage = (wcagViolations)=> {
   return parseFloat((Object.keys(constants.wcagLinks).length - wcagViolations.length) / Object.keys(constants.wcagLinks).length * 100).toFixed(2);
   }
 
-export const getFormattedTime = (timestamp) => {
-  if (timestamp) {
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString('en-GB', {
+  export const getFormattedTime = (inputDate) => {
+    if (inputDate) {
+      return inputDate.toLocaleTimeString('en-GB', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
-      hour12: true,
+      hour12: false,
       hour: 'numeric',
       minute: '2-digit',
     });
@@ -185,23 +185,22 @@ export const getFormattedTime = (timestamp) => {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
-      hour12: true,
+      hour12: false,
       hour: 'numeric',
       minute: '2-digit',
+      timeZoneName: "longGeneric",
     });
   }
 };
 
-export const formatDateTimeForMassScanner = (dateTimeString) => {
-  // Parse the input string to create a Date object
-  const parsedDate = new Date(dateTimeString.replace(/,/g, ''));
+export const formatDateTimeForMassScanner = (date) => {
 
   // Format date and time parts separately
-  const year = parsedDate.getFullYear().toString().slice(-2); // Get the last two digits of the year
-  const month = ('0' + (parsedDate.getMonth() + 1)).slice(-2); // Month is zero-indexed
-  const day = ('0' + parsedDate.getDate()).slice(-2);
-  const hour = ('0' + parsedDate.getHours()).slice(-2);
-  const minute = ('0' + parsedDate.getMinutes()).slice(-2);
+  const year = date.getFullYear().toString().slice(-2); // Get the last two digits of the year
+  const month = ('0' + (date.getMonth() + 1)).slice(-2); // Month is zero-indexed
+  const day = ('0' + date.getDate()).slice(-2);
+  const hour = ('0' + date.getHours()).slice(-2);
+  const minute = ('0' + date.getMinutes()).slice(-2);
 
   // Combine formatted date and time with a slash
   const formattedDateTime = `${day}/${month}/${year} ${hour}:${minute}`;


### PR DESCRIPTION
 - Pluralization issues on report
 - When report is opened in browser, display start time based on viewer's timezone. Start time will be displayed in 24hr format and timezone will be shown.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
