### PR TITLE
added retry for writeSummaryPdf

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -7,7 +7,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import ejs from 'ejs';
 import constants from './constants/constants.js';
-import { createScreenshotsFolder, getFormattedTime, getStoragePath, getVersion, getWcagPassPercentage, formatDateTimeForMassScanner } from './utils.js';
+import { createScreenshotsFolder, getFormattedTime, getStoragePath, getVersion, getWcagPassPercentage, formatDateTimeForMassScanner, retryFunction } from './utils.js';
 import { consoleLogger, silentLogger } from './logs.js';
 import itemTypeDescription from './constants/itemTypeDescription.js';
 import { chromium } from 'playwright';
@@ -571,7 +571,7 @@ export const generateArtifacts = async (
   await writeCsv(allIssues, storagePath);
   await writeHTML(allIssues, storagePath);
   await writeSummaryHTML(allIssues, storagePath);
-  await writeSummaryPdf(storagePath);
+  retryFunction(writeSummaryPdf(storagePath), 1);
   return createRuleIdJson(allIssues);
 };
 

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,7 @@ import os from 'os';
 import { destinationPath, getIntermediateScreenshotsPath } from './constants/constants.js';
 import fs from 'fs-extra';
 import constants from './constants/constants.js';
+import { silentLogger } from './logs.js';
 
 export const getVersion = () => {
   const loadJSON = path => JSON.parse(fs.readFileSync(new URL(path, import.meta.url)));
@@ -288,5 +289,18 @@ export const isFollowStrategy = (link1, link2, rule) =>{
     return link1Domain === link2Domain;
   } else {
     return parsedLink1.hostname === parsedLink2.hostname;
+  }
+}
+
+export const retryFunction = async (func, maxAttempt) => {
+  let attemptCount = 0;
+  while (attemptCount < maxAttempt) {
+    attemptCount++
+    try {
+      const result = await func();
+      return result;
+    } catch (error) {
+      silentLogger.error(`(Attempt count: ${attemptCount} of ${maxAttempt}) ${error}`);
+    }
   }
 }


### PR DESCRIPTION
 - Created a reusable retry function in utils.js
 - used this retry function on writeSummaryPdf to handle error in verbose mode

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
