### PR TITLE
Fix getBrowsrToRun to handle chromium

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -356,7 +356,8 @@ const scanInit = async argvs => {
 
   // File clean up after url check
   // files will clone a second time below if url check passes
-  
+  process.env.PURPLE_A11Y_VERBOSE ? deleteClonedProfiles(data.browser,data.randomToken): deleteClonedProfiles(data.browser) //first deletion
+
   if (argvs.exportDirectory) {
     constants.exportDirectory = argvs.exportDirectory;
   }
@@ -398,7 +399,7 @@ const scanInit = async argvs => {
   }
 
   // Delete cloned directory
-  process.env.PURPLE_A11Y_VERBOSE ? deleteClonedProfiles(data.browser,data.randomToken): deleteClonedProfiles(data.browser)
+  process.env.PURPLE_A11Y_VERBOSE ? deleteClonedProfiles(data.browser,data.randomToken): deleteClonedProfiles(data.browser) //second deletion
 
   // Delete dataset and request queues
   await cleanUp(data.randomToken);

--- a/constants/common.js
+++ b/constants/common.js
@@ -1010,7 +1010,7 @@ export const getBrowserToRun = (preferredBrowser, isCli) => {
     }
   } else {
     // defaults to chromium
-    return { browserToRun: constants.browserTypes.chromium, clonedBrowserDataDir: '' };
+    return { browserToRun: constants.browserTypes.chromium, clonedBrowserDataDir: getDefaultChromiumDataDir() };
   }
 };
 /**


### PR DESCRIPTION
 - handle chromium for getBrowserToRun and added another deleteClonedProfiles

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
