### PR TITLE
refactor: update string for expandedRuleDropdownToggleContainer

### DIFF
--- a/static/ejs/partials/scripts/ruleOffcanvas.ejs
+++ b/static/ejs/partials/scripts/ruleOffcanvas.ejs
@@ -167,7 +167,7 @@ category summary is clicked %>
 
               document.getElementById(`${event.currentTarget.classList[0]}ExpandedRuleDropdownSelector`).classList.add('selected')
 
-              updateExpandedRuleDropdownToggleContainer()
+              updateExpandedRuleDropdownToggleContainer(`(${event.currentTarget.children[1].innerText})`)
 
               ruleInfoText()
 
@@ -187,7 +187,7 @@ category summary is clicked %>
 
               document.getElementById(`${event.currentTarget.classList[0]}OffCanvasButtonSelector`).classList.add('selected')
 
-              updateExpandedRuleDropdownToggleContainer()
+              updateExpandedRuleDropdownToggleContainer(event.currentTarget.children[1].innerText)
 
               ruleInfoText()
 
@@ -231,10 +231,10 @@ category summary is clicked %>
           }
         }
 
-        function updateExpandedRuleDropdownToggleContainer(){
+        function updateExpandedRuleDropdownToggleContainer(dropdownOccurrencesString){
           document.getElementById('expandedRuleDropdownToggleContainer').classList.replace(expandedRuleDropdownToggleContainer.classList[0], event.currentTarget.classList[0]);
           document.getElementById('expandedRuleDropdownToggleCategoryTitle').innerText = event.currentTarget.children[0].innerText.replace(/\n/g, '')
-          document.getElementById('expandedRuleDropdownToggleCategoryInfo').innerText = event.currentTarget.children[1].innerText.replace(/\n/g, '')
+          document.getElementById('expandedRuleDropdownToggleCategoryInfo').innerText = dropdownOccurrencesString
         }
       });
       //  START Script expandedRuleDropdownCategorySelector


### PR DESCRIPTION
This PR adds a refactor to update the string for expandedRuleDropdownToggleContainer:

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
