### PR TITLE
encodeURI, fixes on repeated .pdf sites and refactoring of naming of electron crawling

### DIFF
--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -183,5 +183,14 @@ export const failedRequestHandler = async ({ request }) => {
 
 export const isUrlPdf = url => {
   const parsedUrl = new URL(url);
-  return /\.pdf($|\?|#)/i.test(parsedUrl.pathname);
+  return /\.pdf($|\?|#)/i.test(parsedUrl.pathname) || /\.pdf($|\?|#)/i.test(parsedUrl.href);
 };
+
+export const isUrlZip = (url) => {
+  // Parsing the full URL
+  const parsedUrl = new URL(url);
+  
+  // Checking the whole URL for the .zip pattern, not just the pathname
+  return /\.zip($|\?|#)/i.test(parsedUrl.href);
+};
+

--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -186,11 +186,5 @@ export const isUrlPdf = url => {
   return /\.pdf($|\?|#)/i.test(parsedUrl.pathname) || /\.pdf($|\?|#)/i.test(parsedUrl.href);
 };
 
-export const isUrlZip = (url) => {
-  // Parsing the full URL
-  const parsedUrl = new URL(url);
-  
-  // Checking the whole URL for the .zip pattern, not just the pathname
-  return /\.zip($|\?|#)/i.test(parsedUrl.pathname) || /\.zip($|\?|#)/i.test(parsedUrl.href);
-};
+
 

--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -191,6 +191,6 @@ export const isUrlZip = (url) => {
   const parsedUrl = new URL(url);
   
   // Checking the whole URL for the .zip pattern, not just the pathname
-  return /\.zip($|\?|#)/i.test(parsedUrl.href);
+  return /\.zip($|\?|#)/i.test(parsedUrl.pathname) || /\.zip($|\?|#)/i.test(parsedUrl.href);
 };
 

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -273,16 +273,8 @@ const crawlDomain = async (
         }
       }
 
-      if (isUrlZip(actualUrl)) {
-        guiInfoLog(guiInfoStatusTypes.SKIPPED, {
-          numScanned: urlsCrawled.scanned.length,
-          urlScanned: actualUrl,
-        });
-        return;
-      }
-
       if (!isScanPdfs) {
-        if (isExcluded(actualUrl) || isUrlPdf(actualUrl) || isUrlZip(actualUrl)) {
+        if (isExcluded(actualUrl) || isUrlPdf(actualUrl)) {
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: actualUrl,

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -7,7 +7,6 @@ import {
   preNavigationHooks,
   runAxeScript,
   isUrlPdf,
-  isUrlZip,
 } from './commonCrawlerFunc.js';
 import constants, {
   basicAuthRegex,

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -7,6 +7,7 @@ import {
   preNavigationHooks,
   runAxeScript,
   isUrlPdf,
+  isUrlZip,
 } from './commonCrawlerFunc.js';
 import constants, {
   basicAuthRegex,
@@ -270,7 +271,7 @@ const crawlDomain = async (
         }
       }
       if(!isScanPdfs){
-      if (isExcluded(actualUrl) || isUrlPdf(actualUrl)) {
+      if (isExcluded(actualUrl) || isUrlPdf(actualUrl) || isUrlZip(actualUrl)) {
         guiInfoLog(guiInfoStatusTypes.SKIPPED, {
           numScanned: urlsCrawled.scanned.length,
           urlScanned: actualUrl,
@@ -284,7 +285,7 @@ const crawlDomain = async (
       let finalUrl = page.url(); // Initialize with the request URL
 
 
-      if (isExcluded(actualUrl) || isUrlPdf(actualUrl)) {
+      if (isExcluded(actualUrl) || isUrlPdf(actualUrl) || isUrlZip(actualUrl)) {
         console.log(`Excluded URL (final/redirect): ${finalUrl}`);
         guiInfoLog(guiInfoStatusTypes.SKIPPED, {
           numScanned: urlsCrawled.scanned.length,

--- a/logs.js
+++ b/logs.js
@@ -47,7 +47,7 @@ export const guiInfoLog = (status, data) => {
       case guiInfoStatusTypes.SKIPPED:
       case guiInfoStatusTypes.ERROR:
         console.log(
-          `Electron crawling::${data.numScanned || 0}::${status}::${
+          `crawling::${data.numScanned || 0}::${status}::${
             data.urlScanned || 'no url provided'
           }`,
         );


### PR DESCRIPTION
- Fix for repeated .pdf sites
- Move encode URI to the top of function to prevent playwright regExp Error at globToRegex function
- Rename electron crawling to crawling

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions