### PR TITLE
Detect and skip duplicate URLs

### DIFF
--- a/constants/constants.js
+++ b/constants/constants.js
@@ -219,6 +219,7 @@ export const guiInfoStatusTypes = {
   SKIPPED: 'skipped',
   COMPLETED: 'completed',
   ERROR: 'error',
+  DUPLICATE: 'duplicate',
 };
 
 let launchOptionsArgs = [];

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -264,6 +264,16 @@ const crawlDomain = async (
 
 
       function isExcluded(url) {
+        // Check if duplicate scan URL
+        if (urlsCrawled.scanned.some(item => item.url === url)) {
+          guiInfoLog(guiInfoStatusTypes.DUPLICATE, {
+            numScanned: urlsCrawled.scanned.length,
+            urlScanned: url,
+          });
+          
+          return false;
+        } 
+
         // Check if any pattern matches the URL.
         const blacklistedPatterns = getBlackListedPatterns();
         try {

--- a/logs.js
+++ b/logs.js
@@ -46,6 +46,7 @@ export const guiInfoLog = (status, data) => {
       case guiInfoStatusTypes.SCANNED:
       case guiInfoStatusTypes.SKIPPED:
       case guiInfoStatusTypes.ERROR:
+      case guiInfoStatusTypes.DUPLICATE:
         console.log(
           `crawling::${data.numScanned || 0}::${status}::${
             data.urlScanned || 'no url provided'


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

For website crawl,
- Detect and skip duplicate URLs early in scan stage
- Print to console the status of duplicate urls detected (with current scan count) when `PURPLE_A11Y_VERBOSE` env variable is set / present. It should output to console similar to `crawling::93::duplicate::https://...`

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
