### PR TITLE
Changing datatype for response.data.replace 

### DIFF
--- a/constants/common.js
+++ b/constants/common.js
@@ -275,8 +275,8 @@ const requestToUrl = async (url, isNewCustomFlow, extraHTTPHeaders) => {
     .then(async response => {
       const redirectUrl = response.request.res.responseUrl;
       res.status = constants.urlCheckStatuses.success.code;
-
-      let modifiedHTML = response.data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
+      let data = typeof response.data === 'string' ? response.data : JSON.stringify(response.data);
+      let modifiedHTML = data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
 
       const metaRefreshMatch = /<meta\s+http-equiv="refresh"\s+content="(?:\d+;)?\s*url=(?:'([^']*)'|"([^"]*)"|([^>]*))"/i.exec(modifiedHTML);
 


### PR DESCRIPTION
- Changing datatype for response.data.replace as it only accepts strings not object

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions