### PR TITLE
Incorporate friendly error message instead of technical error browser is busy

### DIFF
--- a/constants/common.js
+++ b/constants/common.js
@@ -1115,10 +1115,10 @@ const cloneChromeProfileCookieFiles = (options, destDir) => {
           } catch (err) {
             silentLogger.error(err);
             if (err.code === 'EBUSY') {
-              console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+              console.log(`Unable to copy the file because it is currently in use.`);
               console.log('Please close any applications that might be using this file and try again.');
             } else {
-              console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${err.message}`);
+              console.log(`An unexpected error occurred while copying the file: ${err.message}`);
             }
             printMessage([err], messageOptions);
             success = false;
@@ -1185,10 +1185,10 @@ const cloneEdgeProfileCookieFiles = (options, destDir) => {
           } catch (err) {
             silentLogger.error(err);
             if (err.code === 'EBUSY') {
-              console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+              console.log(`Unable to copy the file because it is currently in use.`);
               console.log('Please close any applications that might be using this file and try again.');
             } else {
-              console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${err.message}`);
+              console.log(`An unexpected error occurred while copying the file: ${err.message}`);
             }
             printMessage([err], messageOptions);
             success = false;
@@ -1223,10 +1223,10 @@ const cloneLocalStateFile = (options, destDir) => {
       } catch (err) {
         silentLogger.error(err);
         if (err.code === 'EBUSY') {
-          console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+          console.log(`Unable to copy the file because it is currently in use.`);
           console.log('Please close any applications that might be using this file and try again.');
         } else {
-          console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${err.message}`);
+          console.log(`An unexpected error occurred while copying the file: ${err.message}`);
         }
         printMessage([err], messageOptions);
         success = false;

--- a/constants/common.js
+++ b/constants/common.js
@@ -275,9 +275,20 @@ const requestToUrl = async (url, isNewCustomFlow, extraHTTPHeaders) => {
     .then(async response => {
       const redirectUrl = response.request.res.responseUrl;
       res.status = constants.urlCheckStatuses.success.code;
-
-      let modifiedHTML = response.data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
-
+      let data;
+      if (typeof response.data === 'string' || response.data instanceof String) {
+          data = response.data;
+      } else if (typeof response.data === 'object' && response.data !== null) {
+          try {
+              data = JSON.stringify(response.data);
+          } catch (error) {
+              console.log("Error converting object to JSON:", error);
+          }
+      } else {
+          console.log("Unsupported data type:", typeof response.data);
+      }
+      let modifiedHTML = data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
+      
       const metaRefreshMatch = /<meta\s+http-equiv="refresh"\s+content="(?:\d+;)?\s*url=(?:'([^']*)'|"([^"]*)"|([^>]*))"/i.exec(modifiedHTML);
 
       const hasMetaRefresh = metaRefreshMatch && metaRefreshMatch.length > 1;

--- a/constants/common.js
+++ b/constants/common.js
@@ -1115,10 +1115,10 @@ const cloneChromeProfileCookieFiles = (options, destDir) => {
           } catch (err) {
             silentLogger.error(err);
             if (err.code === 'EBUSY') {
-              console.log(`Unable to copy the file because it is currently in use.`);
+              console.log(`Unable to copy the file for ${profileName} because it is currently in use.`);
               console.log('Please close any applications that might be using this file and try again.');
             } else {
-              console.log(`An unexpected error occurred while copying the file: ${err.message}`);
+              console.log(`An unexpected error occurred for ${profileName} while copying the file: ${err.message}`);
             }
             printMessage([err], messageOptions);
             success = false;
@@ -1185,7 +1185,7 @@ const cloneEdgeProfileCookieFiles = (options, destDir) => {
           } catch (err) {
             silentLogger.error(err);
             if (err.code === 'EBUSY') {
-              console.log(`Unable to copy the file because it is currently in use.`);
+              console.log(`Unable to copy the file for ${profileName} because it is currently in use.`);
               console.log('Please close any applications that might be using this file and try again.');
             } else {
               console.log(`An unexpected error occurred while copying the file: ${err.message}`);
@@ -1226,7 +1226,7 @@ const cloneLocalStateFile = (options, destDir) => {
           console.log(`Unable to copy the file because it is currently in use.`);
           console.log('Please close any applications that might be using this file and try again.');
         } else {
-          console.log(`An unexpected error occurred while copying the file: ${err.message}`);
+          console.log(`An unexpected error occurred for ${profileName} while copying the file: ${err.message}`);
         }
         printMessage([err], messageOptions);
         success = false;

--- a/constants/common.js
+++ b/constants/common.js
@@ -729,7 +729,11 @@ export const getLinksFromSitemap = async (
   const addToUrlList = url => {
     if (!url) return;
     if (isDisallowedInRobotsTxt(url)) return;
+    try{
     const request = new Request({ url: encodeURI(url) });
+    } catch(e){
+      console.log(e);
+    }
     if (isUrlPdf(url)) {
       request.skipNavigation = true;
     }

--- a/constants/common.js
+++ b/constants/common.js
@@ -288,7 +288,7 @@ const requestToUrl = async (url, isNewCustomFlow, extraHTTPHeaders) => {
           console.log("Unsupported data type:", typeof response.data);
       }
       let modifiedHTML = data.replace(/<noscript>[\s\S]*?<\/noscript>/gi, '');
-      
+
       const metaRefreshMatch = /<meta\s+http-equiv="refresh"\s+content="(?:\d+;)?\s*url=(?:'([^']*)'|"([^"]*)"|([^>]*))"/i.exec(modifiedHTML);
 
       const hasMetaRefresh = metaRefreshMatch && metaRefreshMatch.length > 1;
@@ -1114,6 +1114,12 @@ const cloneChromeProfileCookieFiles = (options, destDir) => {
             fs.copyFileSync(dir, path.join(destProfileDir, 'Cookies'));
           } catch (err) {
             silentLogger.error(err);
+            if (err.code === 'EBUSY') {
+              console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+              console.log('Please close any applications that might be using this file and try again.');
+            } else {
+              console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${err.message}`);
+            }
             printMessage([err], messageOptions);
             success = false;
           }
@@ -1178,6 +1184,12 @@ const cloneEdgeProfileCookieFiles = (options, destDir) => {
             fs.copyFileSync(dir, path.join(destProfileDir, 'Cookies'));
           } catch (err) {
             silentLogger.error(err);
+            if (err.code === 'EBUSY') {
+              console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+              console.log('Please close any applications that might be using this file and try again.');
+            } else {
+              console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${err.message}`);
+            }
             printMessage([err], messageOptions);
             success = false;
           }
@@ -1210,6 +1222,12 @@ const cloneLocalStateFile = (options, destDir) => {
         fs.copyFileSync(dir, path.join(destDir, 'Local State'));
       } catch (err) {
         silentLogger.error(err);
+        if (err.code === 'EBUSY') {
+          console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+          console.log('Please close any applications that might be using this file and try again.');
+        } else {
+          console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${err.message}`);
+        }
         printMessage([err], messageOptions);
         success = false;
       }

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -219,6 +219,7 @@ export const guiInfoStatusTypes = {
   SKIPPED: 'skipped',
   COMPLETED: 'completed',
   ERROR: 'error',
+  DUPLICATE: 'duplicate',
 };
 
 let launchOptionsArgs = [];

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -263,6 +263,16 @@ const crawlDomain = async (
 
 
       function isExcluded(url) {
+        // Check if duplicate scan URL
+        if (urlsCrawled.scanned.some(item => item.url === url)) {
+          guiInfoLog(guiInfoStatusTypes.DUPLICATE, {
+            numScanned: urlsCrawled.scanned.length,
+            urlScanned: url,
+          });
+          
+          return false;
+        } 
+
         // Check if any pattern matches the URL.
         const blacklistedPatterns = getBlackListedPatterns();
         try {

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -82,9 +82,13 @@ const crawlDomain = async (
    * First time scan with original `url` containing credentials is strictly to authenticate for browser session
    * subsequent URLs are without credentials.
    */
-
+  try{
   url = encodeURI(url);
-
+  }
+  catch(e){
+    console.log(e);
+    silentLogger.info(e);
+  }
   if (basicAuthRegex.test(url)) {
     isBasicAuth = true;
     // request to basic auth URL to authenticate for browser session
@@ -105,7 +109,13 @@ const crawlDomain = async (
       strategy,
       requestQueue,
       transformRequestFunction(req) {
+        try{
         req.url = encodeURI(req.url)
+        }
+        catch(e){
+          console.log(e);
+          silentLogger.info(e);
+        }
         if (urlsCrawled.scanned.some(item => item.url === req.url)) {
           req.skipNavigation = true;
         }
@@ -206,7 +216,13 @@ const crawlDomain = async (
           // handle onclick
           selector: ':not(a):is([role="link"], button[onclick])',
           transformRequestFunction(req) {
+            try{
             req.url = encodeURI(req.url)
+            }
+            catch(e){
+              console.log(e);
+              silentLogger.info(e);
+            }
             if (urlsCrawled.scanned.some(item => item.url === req.url)) {
               req.skipNavigation = true;
             }
@@ -269,7 +285,7 @@ const crawlDomain = async (
             numScanned: urlsCrawled.scanned.length,
             urlScanned: url,
           });
-          
+
           return false;
         } 
 

--- a/logs.js
+++ b/logs.js
@@ -46,6 +46,7 @@ export const guiInfoLog = (status, data) => {
       case guiInfoStatusTypes.SCANNED:
       case guiInfoStatusTypes.SKIPPED:
       case guiInfoStatusTypes.ERROR:
+      case guiInfoStatusTypes.DUPLICATE:
         console.log(
           `crawling::${data.numScanned || 0}::${status}::${
             data.urlScanned || 'no url provided'

--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -571,7 +571,7 @@ export const generateArtifacts = async (
   await writeCsv(allIssues, storagePath);
   await writeHTML(allIssues, storagePath);
   await writeSummaryHTML(allIssues, storagePath);
-  retryFunction(() => writeSummaryPdf(storagePath), 1);
+  await retryFunction(() => writeSummaryPdf(storagePath), 1);
   return createRuleIdJson(allIssues);
 };
 

--- a/utils.js
+++ b/utils.js
@@ -26,7 +26,7 @@ export const isWhitelistedContentType = contentType => {
 };
 
 export const getStoragePath = randomToken => {
-  if (process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH){
+  if (process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH) {
     return `${process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH}/${randomToken}`
   }
   if (constants.exportDirectory === process.cwd()) {
@@ -42,16 +42,29 @@ export const getStoragePath = randomToken => {
 export const createDetailsAndLogs = async (scanDetails, randomToken) => {
   const storagePath = getStoragePath(randomToken);
   const logPath = `logs/${randomToken}`;
-  await fs.ensureDir(storagePath);
-  await fs.writeFile(`${storagePath}/details.json`, JSON.stringify(scanDetails, 0, 2));
+  try {
+    await fs.ensureDir(storagePath);
+    await fs.writeFile(`${storagePath}/details.json`, JSON.stringify(scanDetails, 0, 2));
 
-  // update logs
-  await fs.ensureDir(logPath);
-  await fs.pathExists('errors.txt').then(async exists => {
-    if (exists) {
-      await fs.copy('errors.txt', `${logPath}/${randomToken}.txt`);
-    }
-  });
+    // update logs
+    await fs.ensureDir(logPath);
+    await fs.pathExists('errors.txt').then(async exists => {
+      if (exists) {
+        try {
+          await fs.copy('errors.txt', `${logPath}/${randomToken}.txt`);
+        } catch (error) {
+          if (error.code === 'EBUSY') {
+            console.log(`Unable to copy the file from 'errors.txt' to '${logPath}/${randomToken}.txt' because it is currently in use.`);
+            console.log('Please close any applications that might be using this file and try again.');
+          } else {
+            console.log(`An unexpected error occurred while copying the file: ${error.message}`);
+          }
+        }
+      }
+    });
+  } catch (error) {
+    console.log(`An error occurred while setting up storage or log directories: ${error.message}`);
+  }
 };
 
 export const getUserDataTxt = () => {
@@ -59,12 +72,12 @@ export const getUserDataTxt = () => {
     os.platform() === 'win32'
       ? path.join(process.env.APPDATA, 'Purple A11y', 'userData.txt')
       : path.join(
-          process.env.HOME,
-          'Library',
-          'Application Support',
-          'Purple A11y',
-          'userData.txt',
-        );
+        process.env.HOME,
+        'Library',
+        'Application Support',
+        'Purple A11y',
+        'userData.txt',
+      );
   // check if textFilePath exists
   if (fs.existsSync(textFilePath)) {
     const userData = JSON.parse(fs.readFileSync(textFilePath, 'utf8'));
@@ -78,12 +91,12 @@ export const writeToUserDataTxt = async (key, value) => {
     os.platform() === 'win32'
       ? path.join(process.env.APPDATA, 'Purple A11y', 'userData.txt')
       : path.join(
-          process.env.HOME,
-          'Library',
-          'Application Support',
-          'Purple A11y',
-          'userData.txt',
-        );
+        process.env.HOME,
+        'Library',
+        'Application Support',
+        'Purple A11y',
+        'userData.txt',
+      );
 
   // Create file if it doesn't exist
   if (fs.existsSync(textFilePath)) {
@@ -107,9 +120,18 @@ export const createAndUpdateResultsFolders = async randomToken => {
   const intermediatePdfResultsPath = `${randomToken}/${constants.pdfScanResultFileName}`;
 
   const transferResults = async (intermPath, resultFile) => {
+    try {
     if (fs.existsSync(intermPath)) {
       await fs.copy(intermPath, `${storagePath}/${resultFile}`);
     }
+  } catch (error) {
+    if (error.code === 'EBUSY') {
+      console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+      console.log('Please close any applications that might be using this file and try again.');
+    } else {
+      console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${error.message}`);
+    }
+  }
   };
 
   await Promise.all([
@@ -167,13 +189,13 @@ export const cleanUp = async pathToDelete => {
 //     timeZoneName: "longGeneric",
 //   });
 
-export const getWcagPassPercentage = (wcagViolations)=> {
+export const getWcagPassPercentage = (wcagViolations) => {
   return parseFloat((Object.keys(constants.wcagLinks).length - wcagViolations.length) / Object.keys(constants.wcagLinks).length * 100).toFixed(2);
-  }
+}
 
-  export const getFormattedTime = (inputDate) => {
-    if (inputDate) {
-      return inputDate.toLocaleTimeString('en-GB', {
+export const getFormattedTime = (inputDate) => {
+  if (inputDate) {
+    return inputDate.toLocaleTimeString('en-GB', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -280,12 +302,12 @@ export const randomThreeDigitNumberString = () => {
   return String(threeDigitNumber);
 }
 
-export const isFollowStrategy = (link1, link2, rule) =>{
+export const isFollowStrategy = (link1, link2, rule) => {
   const parsedLink1 = new URL(link1);
   const parsedLink2 = new URL(link2);
-  if (rule === "same-domain"){
+  if (rule === "same-domain") {
     const link1Domain = parsedLink1.hostname.split('.').slice(-2).join('.');
-    const link2Domain = parsedLink2.hostname.split('.').slice(-2).join('.'); 
+    const link2Domain = parsedLink2.hostname.split('.').slice(-2).join('.');
     return link1Domain === link2Domain;
   } else {
     return parsedLink1.hostname === parsedLink2.hostname;

--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,7 @@ export const createDetailsAndLogs = async (scanDetails, randomToken) => {
           await fs.copy('errors.txt', `${logPath}/${randomToken}.txt`);
         } catch (error) {
           if (error.code === 'EBUSY') {
-            console.log(`Unable to copy the file from 'errors.txt' to '${logPath}/${randomToken}.txt' because it is currently in use.`);
+            console.log(`Unable to copy the file because it is currently in use.`);
             console.log('Please close any applications that might be using this file and try again.');
           } else {
             console.log(`An unexpected error occurred while copying the file: ${error.message}`);
@@ -126,10 +126,10 @@ export const createAndUpdateResultsFolders = async randomToken => {
     }
   } catch (error) {
     if (error.code === 'EBUSY') {
-      console.log(`Unable to copy the file from ${intermPath} to ${storagePath}/${resultFile} because it is currently in use.`);
+      console.log(`Unable to copy the file because it is currently in use.`);
       console.log('Please close any applications that might be using this file and try again.');
     } else {
-      console.log(`An unexpected error occurred while copying the file from ${intermPath} to ${storagePath}/${resultFile}: ${error.message}`);
+      console.log(`An unexpected error occurred while copying the file: ${error.message}`);
     }
   }
   };

--- a/utils.js
+++ b/utils.js
@@ -50,16 +50,7 @@ export const createDetailsAndLogs = async (scanDetails, randomToken) => {
     await fs.ensureDir(logPath);
     await fs.pathExists('errors.txt').then(async exists => {
       if (exists) {
-        try {
           await fs.copy('errors.txt', `${logPath}/${randomToken}.txt`);
-        } catch (error) {
-          if (error.code === 'EBUSY') {
-            console.log(`Unable to copy the file because it is currently in use.`);
-            console.log('Please close any applications that might be using this file and try again.');
-          } else {
-            console.log(`An unexpected error occurred while copying the file: ${error.message}`);
-          }
-        }
       }
     });
   } catch (error) {
@@ -120,18 +111,9 @@ export const createAndUpdateResultsFolders = async randomToken => {
   const intermediatePdfResultsPath = `${randomToken}/${constants.pdfScanResultFileName}`;
 
   const transferResults = async (intermPath, resultFile) => {
-    try {
     if (fs.existsSync(intermPath)) {
       await fs.copy(intermPath, `${storagePath}/${resultFile}`);
     }
-  } catch (error) {
-    if (error.code === 'EBUSY') {
-      console.log(`Unable to copy the file because it is currently in use.`);
-      console.log('Please close any applications that might be using this file and try again.');
-    } else {
-      console.log(`An unexpected error occurred while copying the file: ${error.message}`);
-    }
-  }
   };
 
   await Promise.all([

--- a/utils.js
+++ b/utils.js
@@ -27,7 +27,6 @@ export const isWhitelistedContentType = contentType => {
 
 export const getStoragePath = randomToken => {
   if (process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH) {
-  if (process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH) {
     return `${process.env.PURPLE_A11Y_VERBOSE_STORAGE_PATH}/${randomToken}`
   }
   if (constants.exportDirectory === process.cwd()) {
@@ -200,7 +199,6 @@ export const cleanUp = async pathToDelete => {
 //   });
 
 export const getWcagPassPercentage = (wcagViolations) => {
-export const getWcagPassPercentage = (wcagViolations) => {
   return parseFloat((Object.keys(constants.wcagLinks).length - wcagViolations.length) / Object.keys(constants.wcagLinks).length * 100).toFixed(2);
 }
 
@@ -313,7 +311,6 @@ export const randomThreeDigitNumberString = () => {
   return String(threeDigitNumber);
 }
 
-export const isFollowStrategy = (link1, link2, rule) => {
 export const isFollowStrategy = (link1, link2, rule) => {
   const parsedLink1 = new URL(link1);
   const parsedLink2 = new URL(link2);

--- a/utils.js
+++ b/utils.js
@@ -207,9 +207,6 @@ export const getWcagPassPercentage = (wcagViolations) => {
 export const getFormattedTime = (inputDate) => {
   if (inputDate) {
     return inputDate.toLocaleTimeString('en-GB', {
-export const getFormattedTime = (inputDate) => {
-  if (inputDate) {
-    return inputDate.toLocaleTimeString('en-GB', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',

--- a/utils.js
+++ b/utils.js
@@ -81,12 +81,7 @@ export const getUserDataTxt = () => {
         'Purple A11y',
         'userData.txt',
       );
-        process.env.HOME,
-        'Library',
-        'Application Support',
-        'Purple A11y',
-        'userData.txt',
-      );
+        
   // check if textFilePath exists
   if (fs.existsSync(textFilePath)) {
     const userData = JSON.parse(fs.readFileSync(textFilePath, 'utf8'));

--- a/utils.js
+++ b/utils.js
@@ -45,10 +45,7 @@ export const createDetailsAndLogs = async (scanDetails, randomToken) => {
   try {
     await fs.ensureDir(storagePath);
     await fs.writeFile(`${storagePath}/details.json`, JSON.stringify(scanDetails, 0, 2));
-  try {
-    await fs.ensureDir(storagePath);
-    await fs.writeFile(`${storagePath}/details.json`, JSON.stringify(scanDetails, 0, 2));
-
+    
     // update logs
     await fs.ensureDir(logPath);
     await fs.pathExists('errors.txt').then(async exists => {
@@ -309,7 +306,6 @@ export const randomThreeDigitNumberString = () => {
 export const isFollowStrategy = (link1, link2, rule) => {
   const parsedLink1 = new URL(link1);
   const parsedLink2 = new URL(link2);
-  if (rule === "same-domain") {
   if (rule === "same-domain") {
     const link1Domain = parsedLink1.hostname.split('.').slice(-2).join('.');
     const link2Domain = parsedLink2.hostname.split('.').slice(-2).join('.');


### PR DESCRIPTION
- Incorporating friendly error message instead of technical error browser is busy
- Add which web browser is open for users to close easily

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions