### PR TITLE
Fix: summary.pdf not generating

### DIFF
--- a/mergeAxeResults.js
+++ b/mergeAxeResults.js
@@ -571,7 +571,7 @@ export const generateArtifacts = async (
   await writeCsv(allIssues, storagePath);
   await writeHTML(allIssues, storagePath);
   await writeSummaryHTML(allIssues, storagePath);
-  retryFunction(() => writeSummaryPdf(storagePath), 1);
+  await retryFunction(() => writeSummaryPdf(storagePath), 1);
   return createRuleIdJson(allIssues);
 };
 


### PR DESCRIPTION
## Fix: summary.pdf not generating
 - Solution: Add await for retryFunction().

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
