### PR TITLE
Added Single Page Scan under crawlLocalFile, to allow users to scan local files 

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -323,7 +323,6 @@ const scanInit = async argvs => {
     case statuses.invalidUrl.code:
       if (argvs.scanner !== (constants.scannerTypes.sitemap) && argvs.scanner !== (constants.scannerTypes.localFile)) {
         printMessage([statuses.invalidUrl.message], messageOptions);
-        console.log("hi")
         process.exit(res.status);
       }
       /* if sitemap scan is selected, treat this URL as a filepath

--- a/cli.js
+++ b/cli.js
@@ -321,8 +321,9 @@ const scanInit = async argvs => {
       printMessage([statuses.systemError.message], messageOptions);
       process.exit(res.status);
     case statuses.invalidUrl.code:
-      if (argvs.scanner !== constants.scannerTypes.sitemap) {
+      if (argvs.scanner !== (constants.scannerTypes.sitemap) && argvs.scanner !== (constants.scannerTypes.localFile)) {
         printMessage([statuses.invalidUrl.message], messageOptions);
+        console.log("hi")
         process.exit(res.status);
       }
       /* if sitemap scan is selected, treat this URL as a filepath

--- a/combine.js
+++ b/combine.js
@@ -1,6 +1,7 @@
 import printMessage from 'print-message';
 import crawlSitemap from './crawlers/crawlSitemap.js';
 import crawlDomain from './crawlers/crawlDomain.js';
+import crawlLocalFile from './crawlers/crawlLocalFile.js';
 import crawlIntelligentSitemap from './crawlers/crawlIntelligentSitemap.js';
 import { generateArtifacts } from './mergeAxeResults.js';
 import { getHost, createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
@@ -42,7 +43,7 @@ const combineRun = async (details, deviceToScan) => {
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
-  const host = type === constants.scannerTypes.sitemap && isLocalSitemap ? '' : getHost(url);
+  const host = (type === constants.scannerTypes.sitemap && isLocalSitemap || type === constants.scannerTypes.localFile && isLocalSitemap) ? '' : getHost(url);
 
   let blacklistedPatterns = null;
   try {
@@ -86,6 +87,23 @@ const combineRun = async (details, deviceToScan) => {
 
     case constants.scannerTypes.sitemap:
       urlsCrawled = await crawlSitemap(
+        url,
+        randomToken,
+        host,
+        viewportSettings,
+        maxRequestsPerCrawl,
+        browser,
+        userDataDirectory,
+        specifiedMaxConcurrency,
+        fileTypes,
+        blacklistedPatterns,
+        includeScreenshots,
+        extraHTTPHeaders
+      );
+      break;
+
+    case constants.scannerTypes.localFile:
+      urlsCrawled = await crawlLocalFile(
         url,
         randomToken,
         host,

--- a/combine.js
+++ b/combine.js
@@ -102,7 +102,7 @@ const combineRun = async (details, deviceToScan) => {
       break;
 
     case constants.scannerTypes.intelligent:
-        urlsCrawled = await crawlIntelligentSitemap(
+      urlsCrawled = await crawlIntelligentSitemap(
         url,
         randomToken,
         host,
@@ -139,7 +139,7 @@ const combineRun = async (details, deviceToScan) => {
         extraHTTPHeaders,
         safeMode
       );
-    break;
+      break;
 
     default:
       consoleLogger.error(`type: ${type} not defined`);
@@ -150,40 +150,42 @@ const combineRun = async (details, deviceToScan) => {
   scanDetails.endTime = new Date();
   scanDetails.urlsCrawled = urlsCrawled;
   await createDetailsAndLogs(scanDetails, randomToken);
-  if (scanDetails.urlsCrawled.scanned.length > 0) {
-    await createAndUpdateResultsFolders(randomToken);
-    const pagesNotScanned = [
-      ...urlsCrawled.error, 
-      ...urlsCrawled.invalid, 
-      ...urlsCrawled.forbidden
-    ];
-    const basicFormHTMLSnippet = await generateArtifacts(
-      randomToken,
-      url,
-      type,
-      deviceToScan,
-      urlsCrawled.scanned,
-      pagesNotScanned,
-      customFlowLabel,
-      undefined,
-      scanDetails
-    );
-    const [name, email] = nameEmail.split(':');
-    
-    await submitForm(
-      browser,
-      userDataDirectory,
-      url,
-      entryUrl,
-      type,
-      email,
-      name,
-      JSON.stringify(basicFormHTMLSnippet),
-      urlsCrawled.scanned.length,
-      urlsCrawled.scannedRedirects.length, 
-      pagesNotScanned.length,
-      metadata,
-    );
+  if (scanDetails.urlsCrawled) {
+    if (scanDetails.urlsCrawled.scanned.length > 0) {
+      await createAndUpdateResultsFolders(randomToken);
+      const pagesNotScanned = [
+        ...urlsCrawled.error,
+        ...urlsCrawled.invalid,
+        ...urlsCrawled.forbidden
+      ];
+      const basicFormHTMLSnippet = await generateArtifacts(
+        randomToken,
+        url,
+        type,
+        deviceToScan,
+        urlsCrawled.scanned,
+        pagesNotScanned,
+        customFlowLabel,
+        undefined,
+        scanDetails
+      );
+      const [name, email] = nameEmail.split(':');
+
+      await submitForm(
+        browser,
+        userDataDirectory,
+        url,
+        entryUrl,
+        type,
+        email,
+        name,
+        JSON.stringify(basicFormHTMLSnippet),
+        urlsCrawled.scanned.length,
+        urlsCrawled.scannedRedirects.length,
+        pagesNotScanned.length,
+        metadata,
+      );
+    }
   } else {
     printMessage([`No pages were scanned.`], constants.alertMessageOptions);
   }

--- a/constants/common.js
+++ b/constants/common.js
@@ -216,7 +216,9 @@ export const isFileSitemap = async filePath => {
 
   const file = fs.readFileSync(filePath, 'utf8');
   const isLocalSitemap = await isSitemapContent(file);
-  return isLocalSitemap ? filePath : null;
+  let isLocalFileOrSitemap = isLocalSitemap ? filePath : null;
+  let isLocalFiles = file ? filePath : null;
+  return (isLocalFileOrSitemap || isLocalFiles) ? filePath : null;
 };
 
 export const getUrlMessage = scanner => {
@@ -555,7 +557,7 @@ export const prepareData = async argv => {
 
   // construct filename for scan results
   const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
-  const domain = argv.isLocalSitemap ? 'custom' : new URL(argv.url).hostname;
+  const domain = argv.isLocalSitemap ? path.basename(argv.url) : new URL(argv.url).hostname;
   const sanitisedLabel = customFlowLabel ? `_${customFlowLabel.replaceAll(' ', '_')}` : '';
   let resultFilename;
   const randomThreeDigitNumber = randomThreeDigitNumberString()
@@ -729,10 +731,13 @@ export const getLinksFromSitemap = async (
   const addToUrlList = url => {
     if (!url) return;
     if (isDisallowedInRobotsTxt(url)) return;
+    let request;
     try{
-    const request = new Request({ url: encodeURI(url) });
-    } catch(e){
-      console.log(e);
+      request = new Request({ url: encodeURI(url) });
+
+    } catch (e) {
+      console.log('Error creating request:', e);
+
     }
     if (isUrlPdf(url)) {
       request.skipNavigation = true;

--- a/constants/common.js
+++ b/constants/common.js
@@ -229,6 +229,8 @@ export const getUrlMessage = scanner => {
       return 'Please enter URL of website: ';
     case constants.scannerTypes.sitemap:
       return 'Please enter URL or file path to sitemap, or drag and drop a sitemap file here: ';
+    case constants.scannerTypes.localFile:
+      return 'Please enter file path: ';
 
     default:
       return 'Invalid option';
@@ -512,8 +514,10 @@ export const checkUrl = async (
   }
 
   if (
-    res.status === constants.urlCheckStatuses.success.code &&
-    scanner === constants.scannerTypes.sitemap
+    (res.status === constants.urlCheckStatuses.success.code &&
+    scanner === constants.scannerTypes.sitemap) ||
+    (res.status === constants.urlCheckStatuses.success.code &&
+      scanner === constants.scannerTypes.localFile)
   ) {
     const isSitemap = await isSitemapContent(res.content);
 

--- a/constants/constants.js
+++ b/constants/constants.js
@@ -211,7 +211,8 @@ const scannerTypes = {
   website: 'Website',
   custom: 'Custom',
   custom2: 'Custom2',
-  intelligent: 'Intelligent'
+  intelligent: 'Intelligent',
+  localFile: 'LocalFile',
 };
 
 export const guiInfoStatusTypes = {

--- a/constants/questions.js
+++ b/constants/questions.js
@@ -97,7 +97,7 @@ const startScanQuestions = [
         case statuses.systemError.code:
           return statuses.systemError.message;
         case statuses.invalidUrl.code:
-          if (answers.scanner !== constants.scannerTypes.sitemap) {
+          if (answers.scanner !== (constants.scannerTypes.sitemap || constants.scannerTypes.localFile)) {
             return statuses.invalidUrl.message;
           }
 

--- a/crawlers/crawlLocalFile.js
+++ b/crawlers/crawlLocalFile.js
@@ -20,6 +20,7 @@ import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.
 import fs from 'fs';
 import { guiInfoLog } from '../logs.js';
 import playwright from 'playwright';
+import path from 'path';
 
 const crawlSitemap = async (
     sitemapUrl,
@@ -98,7 +99,7 @@ const crawlSitemap = async (
     printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
 
     const request = linksFromSitemap[0];
-    const pdfFileName = getBaseName(request.url);
+    const pdfFileName = path.basename(request.url);
     const trimmedUrl = request.url;
     const destinationFilePath = `${randomToken}/${pdfFileName}`;
     const data = fs.readFileSync(trimmedUrl);

--- a/crawlers/crawlLocalFile.js
+++ b/crawlers/crawlLocalFile.js
@@ -22,7 +22,7 @@ import { guiInfoLog } from '../logs.js';
 import playwright from 'playwright';
 import path from 'path';
 
-const crawlSitemap = async (
+const crawlLocalFile = async (
     sitemapUrl,
     randomToken,
     host,

--- a/crawlers/crawlLocalFile.js
+++ b/crawlers/crawlLocalFile.js
@@ -1,0 +1,164 @@
+import crawlee, { Request } from 'crawlee';
+import printMessage from 'print-message';
+import {
+    createCrawleeSubFolders,
+    preNavigationHooks,
+    runAxeScript,
+    failedRequestHandler,
+    isUrlPdf,
+} from './commonCrawlerFunc.js';
+
+import constants, { guiInfoStatusTypes, basicAuthRegex } from '../constants/constants.js';
+import {
+    getLinksFromSitemap,
+    getPlaywrightLaunchOptions,
+    messageOptions,
+    isSkippedUrl,
+} from '../constants/common.js';
+import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
+import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
+import fs from 'fs';
+import { guiInfoLog } from '../logs.js';
+import playwright from 'playwright';
+
+const crawlSitemap = async (
+    sitemapUrl,
+    randomToken,
+    host,
+    viewportSettings,
+    maxRequestsPerCrawl,
+    browser,
+    userDataDirectory,
+    specifiedMaxConcurrency,
+    fileTypes,
+    blacklistedPatterns,
+    includeScreenshots,
+    extraHTTPHeaders,
+    fromCrawlIntelligentSitemap = false, //optional
+    userUrlInputFromIntelligent = null, //optional
+    datasetFromIntelligent = null, //optional
+    urlsCrawledFromIntelligent = null, //optional
+
+) => {
+    let dataset;
+    let urlsCrawled;
+    let linksFromSitemap
+
+    // Boolean to omit axe scan for basic auth URL
+    let isBasicAuth;
+    let basicAuthPage = 0;
+    let finalLinks = [];
+
+    if (fromCrawlIntelligentSitemap) {
+        dataset = datasetFromIntelligent;
+        urlsCrawled = urlsCrawledFromIntelligent;
+
+    } else {
+        ({ dataset } = await createCrawleeSubFolders(randomToken));
+        urlsCrawled = { ...constants.urlsCrawledObj };
+
+        if (!fs.existsSync(randomToken)) {
+            fs.mkdirSync(randomToken);
+        }
+    }
+
+    if (fs.existsSync(sitemapUrl)) {
+        linksFromSitemap = [new Request({ url: sitemapUrl })];
+    } else {
+        // File not found
+        throw new Error(`File not found: ${sitemapUrl}`);
+    }
+
+    try {
+        sitemapUrl = encodeURI(sitemapUrl)
+    } catch (e) {
+        console.log(e)
+    }
+
+    if (basicAuthRegex.test(sitemapUrl)) {
+        isBasicAuth = true;
+        // request to basic auth URL to authenticate for browser session
+        finalLinks.push(new Request({ url: sitemapUrl, uniqueKey: `auth:${sitemapUrl}` }));
+        const finalUrl = `${sitemapUrl.split('://')[0]}://${sitemapUrl.split('@')[1]}`;
+        // obtain base URL without credentials so that subsequent URLs within the same domain can be scanned
+        finalLinks.push(new Request({ url: finalUrl }));
+        basicAuthPage = -2;
+    }
+
+    let uuidToPdfMapping = {};
+    const isScanHtml = ['all', 'html-only'].includes(fileTypes);
+
+    printMessage(['Fetching URLs. This might take some time...'], { border: false });
+
+    finalLinks = [...finalLinks, ...linksFromSitemap];
+    const requestList = new crawlee.RequestList({
+        sources: finalLinks,
+    });
+    await requestList.initialize();
+    printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
+
+    const request = linksFromSitemap[0];
+    const pdfFileName = getBaseName(request.url);
+    const trimmedUrl = request.url;
+    const destinationFilePath = `${randomToken}/${pdfFileName}`;
+    const data = fs.readFileSync(trimmedUrl);
+    fs.writeFileSync(destinationFilePath, data);
+    uuidToPdfMapping[pdfFileName] = trimmedUrl;
+
+    if (!request.url.endsWith(".pdf")) {
+        let browserUsed;
+        // Playwright only supports chromium,firefox and webkit thus hardcoded to chromium
+        if (browser === "chromium") {
+            browserUsed = await playwright.chromium.launch();
+        }
+        else if (browser === "firefox") {
+            browserUsed = await playwright.firefox.launch();
+        }
+        else if (browser === "webkit") {
+            browserUsed = await playwright.webkit.launch();
+        }
+        else {
+            console.log("Browser not supported, please use chromium, firefox, webkit")
+            console.log(" ")
+            return;
+        }
+        const context = await browserUsed.newContext();
+        const page = await context.newPage();
+        request.url = "file://" + request.url
+        await page.goto(request.url);
+        const results = await runAxeScript(includeScreenshots, page, randomToken);
+        guiInfoLog(guiInfoStatusTypes.SCANNED, {
+            numScanned: urlsCrawled.scanned.length,
+            urlScanned: request.url,
+        });
+
+        urlsCrawled.scanned.push({
+            url: request.url,
+            pageTitle: results.pageTitle,
+            actualUrl: request.loadedUrl, // i.e. actualUrl
+        });
+
+        urlsCrawled.scannedRedirects.push({
+            fromUrl: request.url,
+            toUrl: request.loadedUrl, // i.e. actualUrl
+        });
+
+        results.url = request.url;
+        results.actualUrl = request.loadedUrl;
+
+        await dataset.pushData(results);
+    }
+    else {
+        urlsCrawled.scanned.push({ url: trimmedUrl, pageTitle: pdfFileName });
+
+        await runPdfScan(randomToken);
+        // transform result format
+        const pdfResults = await mapPdfScanResults(randomToken, uuidToPdfMapping);
+
+        // push results for each pdf document to key value store
+        await Promise.all(pdfResults.map(result => dataset.pushData(result)));
+    }
+    return urlsCrawled;
+
+};
+export default crawlLocalFile;

--- a/crawlers/pdfScanFunc.js
+++ b/crawlers/pdfScanFunc.js
@@ -171,79 +171,87 @@ export const mapPdfScanResults = async (randomToken, uuidToUrlMapping) => {
   const intermediateResultPath = `${intermediateFolder}/${constants.pdfScanResultFileName}`;
 
   const rawdata = fs.readFileSync(intermediateResultPath);
-  const output = JSON.parse(rawdata);
+  let output;
+  try {
+    output = JSON.parse(rawdata);
+  } catch (e) {
+    console.log(e);
+  }
 
   const errorMeta = require('../constants/errorMeta.json');
 
   const resultsList = [];
+  if (output) {
+    // jobs: files that are scanned
+    const {
+      report: { jobs },
+    } = output;
 
-  // jobs: files that are scanned
-  const {
-    report: { jobs },
-  } = output;
+    // loop through all jobs
+    for (let jobIdx = 0; jobIdx < jobs.length; jobIdx++) {
+      const translated = {
+        // transformed result for current job
+        goodToFix: {
+          rules: {},
+          totalItems: 0,
+        },
+        mustFix: {
+          rules: {},
+          totalItems: 0,
+        },
+        needsReview: {
+          rules: {},
+          totalItems: 0,
+        },
+      };
 
-  // loop through all jobs
-  for (let jobIdx = 0; jobIdx < jobs.length; jobIdx++) {
-    const translated = {
-      // transformed result for current job
-      goodToFix: {
-        rules: {},
-        totalItems: 0,
-      },
-      mustFix: {
-        rules: {},
-        totalItems: 0,
-      },
-      needsReview: {
-        rules: {},
-        totalItems: 0,
-      },
-    };
+      const { itemDetails, validationResult } = jobs[jobIdx];
+      const { name: fileName } = itemDetails;
 
-    const { itemDetails, validationResult } = jobs[jobIdx];
-    const { name: fileName } = itemDetails;
+      const uuid = fileName
+        .split(os.platform() === 'win32' ? '\\' : '/')
+        .pop()
+        .split('.')
+        .slice(0, -1)
+        .join('.');
+      const url = uuidToUrlMapping[uuid];
+      const pageTitle = decodeURI(url).split('/').pop();
+      const filePath = `${randomToken}/${uuid}.pdf`;
 
-    const uuid = fileName
-      .split(os.platform() === 'win32' ? '\\' : '/')
-      .pop()
-      .split('.')[0];
-    const url = uuidToUrlMapping[uuid];
-    const pageTitle = decodeURI(url).split('/').pop();
-    const filePath = `${randomToken}/${uuid}.pdf`;
+      translated.url = url;
+      translated.pageTitle = pageTitle;
+      translated.filePath = filePath;
 
-    translated.url = url;
-    translated.pageTitle = pageTitle;
-    translated.filePath = filePath;
+      if (!validationResult) {
+        // check for error in scan
+        consoleLogger.info(`Unable to scan ${pageTitle}, skipping`);
+        continue; // skip this job
+      }
 
-    if (!validationResult) {
-      // check for error in scan
-      consoleLogger.info(`Unable to scan ${pageTitle}, skipping`);
-      continue; // skip this job
+      // destructure validation result
+      const { passedChecks, failedChecks, ruleSummaries } = validationResult.details;
+      const totalChecks = passedChecks + failedChecks;
+
+      translated.totalItems = totalChecks;
+
+      // loop through all failed rules
+      for (let ruleIdx = 0; ruleIdx < ruleSummaries.length; ruleIdx++) {
+        const rule = ruleSummaries[ruleIdx];
+        const { specification, testNumber, clause } = rule;
+
+        if (isRuleExcluded(rule)) continue;
+        const [ruleId, transformedRule] = await transformRule(rule, filePath);
+
+        // ignore if violation is not in the meta file
+        const meta = errorMeta[specification][clause][testNumber]?.STATUS ?? 'ignore';
+        const category = translated[metaToCategoryMap[meta]];
+
+        category.rules[ruleId] = transformedRule;
+        category.totalItems += transformedRule.totalItems;
+      }
+
+      resultsList.push(translated);
     }
-
-    // destructure validation result
-    const { passedChecks, failedChecks, ruleSummaries } = validationResult.details;
-    const totalChecks = passedChecks + failedChecks;
-
-    translated.totalItems = totalChecks;
-
-    // loop through all failed rules
-    for (let ruleIdx = 0; ruleIdx < ruleSummaries.length; ruleIdx++) {
-      const rule = ruleSummaries[ruleIdx];
-      const { specification, testNumber, clause } = rule;
-
-      if (isRuleExcluded(rule)) continue;
-      const [ruleId, transformedRule] = await transformRule(rule, filePath);
-
-      // ignore if violation is not in the meta file
-      const meta = errorMeta[specification][clause][testNumber]?.STATUS ?? 'ignore';
-      const category = translated[metaToCategoryMap[meta]];
-
-      category.rules[ruleId] = transformedRule;
-      category.totalItems += transformedRule.totalItems;
-    }
-
-    resultsList.push(translated);
   }
   return resultsList;
 };


### PR DESCRIPTION
- Added crawlLocalFile under crawlSitemap(-c 6)
- Added results and log folder name based on the local file name given
- Added try catch to all the json parsing for sitemap
- Fix bug of able to scan files with dot separator within the file name
- Allow all types of files to be scanned (verapdf for pdf files, axescript for non pdf files

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions