### PR TITLE
connections and loading issue on specific sites

### DIFF
--- a/constants/common.js
+++ b/constants/common.js
@@ -1534,7 +1534,7 @@ export const submitFormViaPlaywright = async (browserToRun, userDataDirectory, f
   try {
     const response = await page.goto(finalUrl, {
       timeout: 30000,
-      ...(proxy && { waitUntil: 'load' }),
+      ...(proxy && { waitUntil: 'commit' }),
     });
 
     try {

--- a/constants/common.js
+++ b/constants/common.js
@@ -141,6 +141,7 @@ const document = new JSDOM('').window;
 const httpsAgent = new https.Agent({
   // Run in environments with custom certificates
   rejectUnauthorized: false,
+  keepAlive: true,
 });
 
 export const messageOptions = {
@@ -684,6 +685,7 @@ const getRobotsTxtViaAxios = async (robotsUrl) => {
   const instance = axios.create({
     httpsAgent: new https.Agent({
       rejectUnauthorized: false,
+      keepAlive: true,
     }),
   });
 
@@ -855,6 +857,7 @@ export const getLinksFromSitemap = async (
           const instance = axios.create({
             httpsAgent: new https.Agent({
               rejectUnauthorized: false,
+              keepAlive: true,
             }),
           });
           data = await (await instance.get(url, { timeout: 80000 })).data;
@@ -1531,7 +1534,7 @@ export const submitFormViaPlaywright = async (browserToRun, userDataDirectory, f
   try {
     const response = await page.goto(finalUrl, {
       timeout: 30000,
-      ...(proxy && { waitUntil: 'commit' }),
+      ...(proxy && { waitUntil: 'load' }),
     });
 
     try {

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -315,7 +315,7 @@ const crawlDomain = async (
         }
 
         // Ensure page navigation completes to capture final URL in a redirect chain
-        await page.goto(request.url, { waitUntil: 'networkidle' });
+        await page.goto(request.url, { waitUntil: 'load' });
 
         let finalUrl = page.url(); // Initialize with the request URL
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/purple-hats",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/purple-hats",
-      "version": "0.9.52",
+      "version": "0.9.53",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",
@@ -22,7 +22,7 @@
         "lodash": "^4.17.21",
         "minimatch": "^9.0.3",
         "pdfjs-dist": "github:veraPDF/pdfjs-dist#v2.14.305-taggedPdf-0.1.11",
-        "playwright": "1.42.1",
+        "playwright": "1.44.0",
         "prettier": "^3.1.0",
         "print-message": "^3.0.1",
         "safe-regex": "^2.1.1",
@@ -7454,11 +7454,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.44.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7471,9 +7471,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/purple-hats",
   "main": "npmIndex.js",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "type": "module",
   "imports": {
     "#root/*.js": "./*.js"
@@ -20,7 +20,7 @@
     "lodash": "^4.17.21",
     "minimatch": "^9.0.3",
     "pdfjs-dist": "github:veraPDF/pdfjs-dist#v2.14.305-taggedPdf-0.1.11",
-    "playwright": "1.42.1",
+    "playwright": "1.44.0",
     "prettier": "^3.1.0",
     "print-message": "^3.0.1",
     "safe-regex": "^2.1.1",


### PR DESCRIPTION
- Added axios keepAlive as true to reduce connection errors with sites such as watsons.com.sg
- Fix scan issue with guardian.com.sg by changing page.goto wait to load instead of networkidle

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions