### PR TITLE
Port over logic from crawlDomain

### DIFF
--- a/constants/common.js
+++ b/constants/common.js
@@ -1656,3 +1656,11 @@ export const getPlaywrightLaunchOptions = browser => {
   }
   return options;
 };
+
+export const waitForPageLoaded = async (page, timeout = 10000) => {
+  return Promise.race([
+      page.waitForLoadState('load'),
+      page.waitForLoadState('networkidle'),
+      new Promise((resolve) => setTimeout(resolve, timeout))
+  ]);
+}

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -20,6 +20,7 @@ import {
   isDisallowedInRobotsTxt,
   getUrlsFromRobotsTxt,
   getBlackListedPatterns,
+  waitForPageLoaded,
 } from '../constants/common.js';
 import { areLinksEqual, isFollowStrategy } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -334,14 +335,6 @@ const crawlDomain = async (
         if (isBasicAuth) await page.setExtraHTTPHeaders({
           'Authorization': authHeader
         });
-        
-        const waitForPageLoaded = async (page, timeout = 10000) => {
-          return Promise.race([
-              page.waitForLoadState('load'),
-              page.waitForLoadState('networkidle'),
-              new Promise((resolve) => setTimeout(resolve, timeout))
-          ]);
-        }
 
         await waitForPageLoaded(page, 10000);
         const actualUrl = page.url(); // Initialize with the actual URL


### PR DESCRIPTION
## Logic copied over from crawDomain to CrawlSitemap
 - userDataDir
 - requestHandlerTimeoutSecs
 - waitForPageLoaded
 
Side note: shifted waitForPageLoaded function to common.js

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
