### PR TITLE
Chore/typescript syntax and improv/report.html

### DIFF
--- a/__mocks__/mockFunctions.ts
+++ b/__mocks__/mockFunctions.ts
@@ -21,11 +21,6 @@ export const createAlertMessage = jest.fn(warnlevel => [
   { border: true, borderColor: 'red' },
 ]);
 
-export const createFilenames = jest.fn(() => {
-  const allFiles = actualFs.readdirSync(actualPath.resolve('./__mocks__/mock_all_issues'));
-  return allFiles;
-});
-
 export const createFinalResultsInJson = jest.fn((allissues, dateTimeStamp) => {
   const finalResultsInJson = JSON.stringify(
     { startTime: dateTimeStamp, count: allissues.length, allissues },

--- a/__tests__/mergeAxeResults.test.ts
+++ b/__tests__/mergeAxeResults.test.ts
@@ -40,8 +40,6 @@ const { consoleLogger, silentLogger } = require('../logs');
 let randomToken;
 let currentDate;
 let expectedStoragePath;
-let expectedDirPath;
-let allIssuesDirectory;
 let expectedJsonFilename;
 let expectedHTMLFilename;
 let htmlFilename;
@@ -55,14 +53,9 @@ beforeEach(() => {
   randomToken = '162282454060d4c8470d';
   currentDate = getCurrentDate();
   expectedStoragePath = `results/${currentDate}/${randomToken}`;
-  expectedDirPath = `results/${currentDate}/${randomToken}/all_issues`;
-  allIssuesDirectory = `${expectedStoragePath}/all_issues`;
-  expectedFilenames = ['000000001.json', '000000002.json'];
 
   // Reports storagePath, expected report and compiled result files
   htmlFilename = 'report';
-  jsonFilename = 'compiledResults';
-  expectedJsonFilename = `${expectedStoragePath}/reports/${jsonFilename}.json`;
   expectedHTMLFilename = `${expectedStoragePath}/reports/${htmlFilename}.html`;
 
   // Mock the JSON result generated from the issues
@@ -159,45 +152,6 @@ describe('test threshold limit check', () => {
       expect(printMessage.mock.calls[1]).toEqual(expectedAlertMessage);
     },
   );
-});
-
-describe('test extract file names', () => {
-  afterEach(() => {
-    fs.readdir.mockRestore();
-  });
-
-  test('should return list of JSON files', async () => {
-    fs.readdir.mockResolvedValue(createFilenames());
-    const result = await extractFileNames(allIssuesDirectory);
-
-    expect(fs.readdir).toHaveBeenCalled();
-    expect(fs.readdir.mock.calls[0][0]).toEqual(expectedDirPath);
-    expect(result).not.toBe(fs.readdir.mock.results[0].value);
-    expect(result).toEqual(expectedFilenames);
-  });
-
-  test('should print error message when fail to read directory', async () => {
-    fs.readdir.mockResolvedValue(undefined);
-
-    const spyConsoleLogger = jest.spyOn(consoleLogger, 'info').mockImplementation();
-    const spySilentLogger = jest.spyOn(silentLogger, 'error').mockImplementation();
-    const result = await extractFileNames(allIssuesDirectory);
-    expect(spyConsoleLogger.mock.calls[0][0]).toEqual(
-      'An error has occurred when retrieving files, please try again.',
-    );
-
-    expect(spySilentLogger.mock.calls[0][0].toString()).toMatch(
-      /\(extractFileNames\) - TypeError: Cannot read/i,
-    );
-
-    expect(result).toBeUndefined();
-  });
-
-  test('should return empty array when no filenames extracted', async () => {
-    fs.readdir.mockResolvedValue([]);
-    const result = await extractFileNames(allIssuesDirectory);
-    expect(result).toMatchObject([]);
-  });
 });
 
 describe('test parsing content to json', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/purple-hats",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/purple-hats",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",
@@ -48,7 +48,7 @@
         "eslint-plugin-import": "^2.27.4",
         "eslint-plugin-prettier": "^5.0.0",
         "globals": "^15.2.0",
-        "jest": "^29.3.1"
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2949,12 +2949,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4590,9 +4590,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/purple-hats",
   "main": "dist/npmIndex.js",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "imports": {
     "#root/*.js": "./dist/*.js"
@@ -46,7 +46,7 @@
     "eslint-plugin-import": "^2.27.4",
     "eslint-plugin-prettier": "^5.0.0",
     "globals": "^15.2.0",
-    "jest": "^29.3.1"
+    "jest": "^29.7.0"
   },
   "overrides": {
     "node-fetch": "^2.3.0",

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -170,8 +170,6 @@ const combineRun = async (details, deviceToScan) => {
     );
     const [name, email] = nameEmail.split(':');
 
-    console.log("urlsCrawled",urlsCrawledObj);
-
     await submitForm(
       browser,
       userDataDirectory,

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -167,7 +167,7 @@ const combineRun = async (details:Data, deviceToScan:string) => {
 
   scanDetails.endTime = new Date();
   scanDetails.urlsCrawled = urlsCrawledObj;
-  await createDetailsAndLogs(scanDetails, randomToken);
+  await createDetailsAndLogs(randomToken);
   if (scanDetails.urlsCrawled.scanned.length > 0) {
     await createAndUpdateResultsFolders(randomToken);
     const pagesNotScanned = [

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -9,8 +9,26 @@ import { getBlackListedPatterns, submitForm, urlWithoutAuth } from './constants/
 import { consoleLogger, silentLogger } from './logs.js';
 import runCustom from './crawlers/runCustom.js';
 import { alertMessageOptions } from './constants/cliFunctions.js';
+import { Data } from './index.js';
 
-const combineRun = async (details, deviceToScan) => {
+
+// Class exports
+export class ViewportSettingsClass {
+  deviceChosen: string;
+  customDevice: string;
+  viewportWidth: number;
+  playwrightDeviceDetailsObject: any; // You can replace 'any' with a more specific type if possible
+
+  constructor(deviceChosen: string, customDevice: string, viewportWidth: number, playwrightDeviceDetailsObject: any) {
+    this.deviceChosen = deviceChosen;
+    this.customDevice = customDevice;
+    this.viewportWidth = viewportWidth;
+    this.playwrightDeviceDetailsObject = playwrightDeviceDetailsObject;
+  }
+}
+
+
+const combineRun = async (details:Data, deviceToScan:string) => {
   const envDetails = { ...details };
 
   const {
@@ -44,7 +62,7 @@ const combineRun = async (details, deviceToScan) => {
 
   const host = type === ScannerTypes.SITEMAP && isLocalSitemap ? '' : getHost(url);
 
-  let blacklistedPatterns = null;
+  let blacklistedPatterns:string[] | null = null;
   try {
     blacklistedPatterns = getBlackListedPatterns(blacklistedPatternsFilename);
   } catch (error) {
@@ -65,12 +83,12 @@ const combineRun = async (details, deviceToScan) => {
 
   };
 
-  const viewportSettings = {
+  const viewportSettings:ViewportSettingsClass = new ViewportSettingsClass(
     deviceChosen,
     customDevice,
     viewportWidth,
     playwrightDeviceDetailsObject,
-  };
+  );
 
   let urlsCrawledObj;
   switch (type) {

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -4,7 +4,7 @@ import crawlDomain from './crawlers/crawlDomain.js';
 import crawlIntelligentSitemap from './crawlers/crawlIntelligentSitemap.js';
 import { generateArtifacts } from './mergeAxeResults.js';
 import { getHost, createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
-import urlsCrawledObj,{ ScannerTypes,UrlsCrawled} from './constants/constants.js';
+import { ScannerTypes,UrlsCrawled} from './constants/constants.js';
 import { getBlackListedPatterns, submitForm, urlWithoutAuth } from './constants/common.js';
 import { consoleLogger, silentLogger } from './logs.js';
 import runCustom from './crawlers/runCustom.js';

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -4,7 +4,7 @@ import crawlDomain from './crawlers/crawlDomain.js';
 import crawlIntelligentSitemap from './crawlers/crawlIntelligentSitemap.js';
 import { generateArtifacts } from './mergeAxeResults.js';
 import { getHost, createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
-import urlsCrawledObj, { ScannerTypes } from './constants/constants.js';
+import urlsCrawledObj,{ ScannerTypes,UrlsCrawled} from './constants/constants.js';
 import { getBlackListedPatterns, submitForm, urlWithoutAuth } from './constants/common.js';
 import { consoleLogger, silentLogger } from './logs.js';
 import runCustom from './crawlers/runCustom.js';
@@ -58,8 +58,11 @@ const combineRun = async (details, deviceToScan) => {
 
   const scanDetails = {
     startTime: new Date(),
+    endTime: new Date(),
     crawlType: type,
     requestUrl: finalUrl,
+    urlsCrawled: new UrlsCrawled(),
+
   };
 
   const viewportSettings = {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1022,7 +1022,6 @@ export const getBrowserToRun = (
   preferredBrowser: BrowserTypes,
   isCli = false,
 ): { browserToRun: BrowserTypes; clonedBrowserDataDir: string } => {
-  console.log(`Preferred browser ${preferredBrowser}`);
 
   const platform = os.platform();
 
@@ -1030,6 +1029,8 @@ export const getBrowserToRun = (
   if (!preferredBrowser && (os.platform() === 'win32' || os.platform() === 'darwin')) {
     preferredBrowser = BrowserTypes.CHROME;
   }
+
+  printMessage([`Preferred browser ${preferredBrowser}`], messageOptions);
 
   if (preferredBrowser === BrowserTypes.CHROME) {
     const chromeData = getChromeData();

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -118,7 +118,7 @@ export const validateFilePath = (filePath: string, cliDir: string) => {
   }
 };
 
-export const getBlackListedPatterns = (blacklistedPatternsFilename: string): string[] | null=> {
+export const getBlackListedPatterns = (blacklistedPatternsFilename: string|null): string[] | null=> {
   let exclusionsFile = null;
   if (blacklistedPatternsFilename) {
     exclusionsFile = blacklistedPatternsFilename;

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -118,7 +118,7 @@ export const validateFilePath = (filePath: string, cliDir: string) => {
   }
 };
 
-export const getBlackListedPatterns = (blacklistedPatternsFilename: string) => {
+export const getBlackListedPatterns = (blacklistedPatternsFilename: string): string[] | null=> {
   let exclusionsFile = null;
   if (blacklistedPatternsFilename) {
     exclusionsFile = blacklistedPatternsFilename;
@@ -1647,7 +1647,7 @@ export const submitFormViaPlaywright = async (
 };
 
 export const submitForm = async (
-  browserToRun: BrowserTypes,
+  browserToRun: string,
   userDataDirectory: string,
   scannedUrl: string,
   entryUrl: string,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -182,21 +182,28 @@ export const basicAuthRegex = /^.*\/\/.*:.*@.*$/i;
 
 // for crawlers
 export const axeScript = path.join(__dirname, '../../node_modules/axe-core/axe.min.js');
+export class UrlsCrawled {
+  toScan: string[] = [];
+  scanned: string[] = [];
+  invalid: string[] = [];
+  scannedRedirects: string[] = [];
+  notScannedRedirects: string[] = [];
+  outOfDomain: string[] = [];
+  blacklisted: string[] = [];
+  error: string[] = [];
+  exceededRequests: string[] = [];
+  forbidden: string[] = [];
+  userExcluded: string[] = [];
+  everything: string[] = [];
+  
+  constructor(urlsCrawled?: Partial<UrlsCrawled>) {
+    if (urlsCrawled) {
+      Object.assign(this, urlsCrawled);
+    }
+  }
+}
 
-const  urlsCrawledObj = {
-  toScan: [],
-  scanned: [],
-  invalid: [],
-  scannedRedirects: [],
-  notScannedRedirects: [],
-  outOfDomain: [],
-  blacklisted: [],
-  error: [],
-  exceededRequests: [],
-  forbidden: [],
-  userExcluded: [],
-  everything: [],
-};
+const urlsCrawledObj = new UrlsCrawled();
 
 export enum ScannerTypes {
   SITEMAP = 'Sitemap',

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -183,7 +183,7 @@ export const basicAuthRegex = /^.*\/\/.*:.*@.*$/i;
 // for crawlers
 export const axeScript = path.join(__dirname, '../../node_modules/axe-core/axe.min.js');
 
-const urlsCrawledObj = {
+const  urlsCrawledObj = {
   toScan: [],
   scanned: [],
   invalid: [],

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -402,7 +402,6 @@ const reserveFileNameKeywords = [
 ];
 
 export default {
-  allIssueFileName: 'all_issues',
   cliZipFileName: 'a11y-scan-results.zip',
   exportDirectory: `${process.cwd()}`,
   maxRequestsPerCrawl,

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -6,7 +6,43 @@ import { axeScript, guiInfoStatusTypes, saflyIconSelector } from '../constants/c
 import { guiInfoLog } from '../logs.js';
 import { takeScreenshotForHTMLElements } from '../screenshotFunc/htmlScreenshotFunc.js';
 
-export const filterAxeResults = (results, pageTitle, customFlowDetails) => {
+// types
+type RuleDetails = {
+  [key: string]: any[];
+};
+
+type ResultCategory = {
+  totalItems: number;
+  rules: RuleDetails;
+};
+
+type CustomFlowDetails = {
+  pageIndex?: any;
+  metadata?: any;
+  pageImagePath?: any;
+};
+
+type FilteredResults = {
+  url: string;
+  pageTitle: string;
+  pageIndex?: any;
+  metadata?: any;
+  pageImagePath?: any;
+  totalItems: number;
+  mustFix: ResultCategory;
+  goodToFix: ResultCategory;
+  needsReview: ResultCategory;
+  passed: ResultCategory;
+  actualUrl?: string;
+};
+
+export const filterAxeResults = (
+  results: any,
+  pageTitle: string,
+  customFlowDetails?: CustomFlowDetails,
+): FilteredResults => {
+
+
   const { violations, passes, incomplete, url } = results;
 
   let totalItems = 0;

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -158,7 +158,7 @@ export const runAxeScript = async (
 };
 
 export const createCrawleeSubFolders = async randomToken => {
-  const dataset = await crawlee.Dataset.open(randomToken);
+  const dataset= await crawlee.Dataset.open(randomToken);
   const requestQueue = await crawlee.RequestQueue.open(randomToken);
   return { dataset, requestQueue };
 };

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -132,6 +132,9 @@ export const runAxeScript = async (
         branding: {
           application: 'purple-a11y',
         },
+        rules: [
+          { id: 'target-size', enabled: true },
+        ]
       });
 
       //removed needsReview condition

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
 import crawlee from 'crawlee';
-import axe from 'axe-core';
+import axe, { resultGroups } from 'axe-core';
 import { axeScript, guiInfoStatusTypes, saflyIconSelector } from '../constants/constants.js';
 import { guiInfoLog } from '../logs.js';
 import { takeScreenshotForHTMLElements } from '../screenshotFunc/htmlScreenshotFunc.js';
@@ -138,7 +138,7 @@ export const runAxeScript = async (
       });
 
       //removed needsReview condition
-      defaultResultTypes = ['violations', 'passes', 'incomplete']
+      let defaultResultTypes:resultGroups[]= ['violations', 'passes', 'incomplete']
         
 
       return axe.run(selectors, {
@@ -175,7 +175,7 @@ export const preNavigationHooks = (extraHTTPHeaders) => {
 
 export const postNavigationHooks = [
   async _crawlingContext => {
-    guiInfoLog(guiInfoStatusTypes.COMPLETED);
+    guiInfoLog(guiInfoStatusTypes.COMPLETED,{});
   },
 ];
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -42,7 +42,7 @@ const crawlDomain = async (
   includeScreenshots,
   followRobots,
   extraHTTPHeaders,
-  safeMode,
+  safeMode = false, // optional
   fromCrawlIntelligentSitemap = false, //optional
   datasetFromIntelligent = null, //optional
   urlsCrawledFromIntelligent = null, //optional
@@ -509,7 +509,7 @@ const crawlDomain = async (
             urlsCrawled.blacklisted.push(request.url);
             return;
           }
-          const { pdfFileName, trimmedUrl } = handlePdfDownload(
+          const { pdfFileName, url } = handlePdfDownload(
             randomToken,
             pdfDownloads,
             request,
@@ -517,7 +517,7 @@ const crawlDomain = async (
             urlsCrawled,
           );
 
-          uuidToPdfMapping[pdfFileName] = trimmedUrl;
+          uuidToPdfMapping[pdfFileName] = url;
           return;
         }
 
@@ -717,7 +717,7 @@ const crawlDomain = async (
   }
 
   if (!fromCrawlIntelligentSitemap) {
-    guiInfoLog(guiInfoStatusTypes.COMPLETED);
+    guiInfoLog(guiInfoStatusTypes.COMPLETED, {});
   }
 
   return urlsCrawled;

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -77,11 +77,13 @@ const crawlDomain = async (
   let authHeader = '';
 
   // Test basic auth and add auth header if auth exist
-  const parsedUrl = new URL(url);
+  const parsedUrl = new URL(url); 
+  let username:string;
+  let password:string;
   if (parsedUrl.username !== '' && parsedUrl.password !== '') {
     isBasicAuth = true;
-    const username = decodeURIComponent(parsedUrl.username);
-    const password = decodeURIComponent(parsedUrl.password);
+    username= decodeURIComponent(parsedUrl.username);
+    password = decodeURIComponent(parsedUrl.password);
 
     // Create auth header
     authHeader = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
@@ -455,9 +457,15 @@ const crawlDomain = async (
       try {
         // Set basic auth header if needed
         if (isBasicAuth)
+        {
           await page.setExtraHTTPHeaders({
             Authorization: authHeader,
           });
+          const currentUrl = new URL(request.url);
+          currentUrl.username = username;
+          currentUrl.password = password;
+          request.url = currentUrl.href;          
+        }
 
         await waitForPageLoaded(page, 10000);
         let actualUrl = request.url;

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -132,6 +132,8 @@ import {chromium} from 'playwright';
 
     if (urlsCrawled.scanned.length < maxRequestsPerCrawl){ 
       // run crawl domain starting from root website, only on pages not scanned before
+      console.log("HEY urlsCrawled.scanned.length< maxRequestsPerCrawl", urlsCrawled.scanned.length)
+      let urlsCrawledFromIntelligent = urlsCrawled;
       urlsCrawledFinal = await crawlDomain(
         url,
         randomToken,
@@ -147,10 +149,10 @@ import {chromium} from 'playwright';
         includeScreenshots,
         followRobots,
         extraHTTPHeaders,
+        safeMode,
         fromCrawlIntelligentSitemap,
         dataset, //for crawlDomain to add on to
-        urlsCrawled, //urls for crawlDomain to exclude
-        safeMode
+        urlsCrawledFromIntelligent, //urls for crawlDomain to exclude
       )
     }
 

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -154,7 +154,7 @@ import {chromium} from 'playwright';
       )
     }
 
-    guiInfoLog(guiInfoStatusTypes.COMPLETED);
+    guiInfoLog(guiInfoStatusTypes.COMPLETED,{});
     return urlsCrawledFinal;
 
   };

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -132,7 +132,6 @@ import {chromium} from 'playwright';
 
     if (urlsCrawled.scanned.length < maxRequestsPerCrawl){ 
       // run crawl domain starting from root website, only on pages not scanned before
-      console.log("HEY urlsCrawled.scanned.length< maxRequestsPerCrawl", urlsCrawled.scanned.length)
       let urlsCrawledFromIntelligent = urlsCrawled;
       urlsCrawledFinal = await crawlDomain(
         url,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -1,4 +1,4 @@
-import crawlee, { Request } from 'crawlee';
+import crawlee, { Request,RequestList } from 'crawlee';
 import printMessage from 'print-message';
 import {
   createCrawleeSubFolders,
@@ -118,10 +118,7 @@ const crawlSitemap = async (
 
   finalLinks = [...finalLinks, ...linksFromSitemap];
 
-  const requestList = new crawlee.RequestList({
-    sources: finalLinks,
-  });
-  await requestList.initialize();
+  const requestList = await RequestList.open('my-request-list', finalLinks)
   printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
 
   const crawler = new crawlee.PlaywrightCrawler({
@@ -167,9 +164,16 @@ const crawlSitemap = async (
       await waitForPageLoaded(page, 10000);
 
       // Set basic auth header if needed
-      if (isBasicAuth) await page.setExtraHTTPHeaders({
-        'Authorization': authHeader
-      });
+      if (isBasicAuth) {
+        await page.setExtraHTTPHeaders({
+          'Authorization': authHeader
+        });
+        const currentUrl = new URL(request.url);
+        currentUrl.username = username;
+        currentUrl.password = password;
+        request.url = currentUrl.href;
+      }
+      
       
       const actualUrl = request.loadedUrl || request.url;
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -118,7 +118,9 @@ const crawlSitemap = async (
 
   finalLinks = [...finalLinks, ...linksFromSitemap];
 
-  const requestList = await RequestList.open('my-request-list', finalLinks)
+  const requestList = await RequestList.open({
+    sources: finalLinks,
+  });
   printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
 
   const crawler = new crawlee.PlaywrightCrawler({
@@ -192,7 +194,7 @@ const crawlSitemap = async (
           return;
         }
         // pushes download promise into pdfDownloads
-        const { pdfFileName, trimmedUrl } = handlePdfDownload(
+        const { pdfFileName, url } = handlePdfDownload(
           randomToken,
           pdfDownloads,
           request,
@@ -200,7 +202,7 @@ const crawlSitemap = async (
           urlsCrawled,
         );
 
-        uuidToPdfMapping[pdfFileName] = trimmedUrl;
+        uuidToPdfMapping[pdfFileName] = url;
         return;
       }
 
@@ -234,7 +236,7 @@ const crawlSitemap = async (
         basicAuthPage++;
       } else {
         if (isScanHtml && status === 200 && isWhitelistedContentType(contentType)) {
-          const results = await runAxeScript(includeScreenshots, page, randomToken);
+          const results = await runAxeScript(includeScreenshots, page, randomToken, null);
           guiInfoLog(guiInfoStatusTypes.SCANNED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
@@ -333,7 +335,7 @@ const crawlSitemap = async (
 
   
   if (!fromCrawlIntelligentSitemap){
-    guiInfoLog(guiInfoStatusTypes.COMPLETED);
+    guiInfoLog(guiInfoStatusTypes.COMPLETED, {});
   }
 
   return urlsCrawled;

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -16,7 +16,7 @@ export const log = str => {
 };
 
 
-export const screenshotFullPage = async (page, screenshotsDir, screenshotIdx) => {
+export const screenshotFullPage = async (page, screenshotsDir:string, screenshotIdx) => {
   const imgName = `PHScan-screenshot${screenshotIdx}.png`;
   const imgPath = path.join(screenshotsDir, imgName);
 

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -77,17 +77,25 @@ export const screenshotFullPage = async (page, screenshotsDir:string, screenshot
   consoleLogger.info(`Screenshot page at: ${urlWithoutAuth(page.url())}`);
   silentLogger.info(`Screenshot page at: ${urlWithoutAuth(page.url())}`);
 
-  await page.screenshot({
-    path: imgPath,
-    clip: {
-      x: 0,
-      y: 0,
-      width: fullPageSize.width,
-      height: 5400,
-    },
-    fullPage: true,
-    scale: 'css',
-  });
+  try {
+    await page.screenshot({
+      timeout: 10000,
+      path: imgPath,
+      clip: {
+        x: 0,
+        y: 0,
+        width: fullPageSize.width,
+        height: 5400,
+      },
+      fullPage: true,
+      scale: 'css',
+    });
+  
+    if (originalSize) await page.setViewportSize(originalSize);
+  
+  } catch (e) {
+    consoleLogger.error('Unable to take screenshot');
+  }
 
   if (originalSize) await page.setViewportSize(originalSize);
 

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -15,6 +15,7 @@ export const log = str => {
   }
 };
 
+
 export const screenshotFullPage = async (page, screenshotsDir, screenshotIdx) => {
   const imgName = `PHScan-screenshot${screenshotIdx}.png`;
   const imgPath = path.join(screenshotsDir, imgName);
@@ -204,7 +205,7 @@ export const updateMenu = async (page, urlsCrawled) => {
       if (shadowHost) {
         const p = shadowHost.shadowRoot.querySelector('#purple-a11y-p-pages-scanned');
         if (p) {
-          p.innerText = `Pages Scanned: ${vars.urlsCrawled.scanned.length || 0}`;
+          p.textContent = `Pages Scanned: ${vars.urlsCrawled.scanned.length || 0}`;
         }
       }
     },
@@ -216,6 +217,10 @@ export const updateMenu = async (page, urlsCrawled) => {
 export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
   await page.waitForLoadState('domcontentloaded');
   log(`Overlay menu: adding to ${menuPos}...`);
+  interface CustomWindow extends Window {
+    updateMenuPos: (newPos: any) => void;
+    handleOnScanClick: () => void;
+  }
 
   // Add the overlay menu with initial styling
   return page
@@ -233,7 +238,10 @@ export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
         let offsetY;
 
         menu.addEventListener('mousedown', e => {
-          if (e.target.tagName.toLowerCase() !== 'button') {
+          // The EvenTarget Object is the grandfather interface for Element
+          // In order to get the tagName of the item you would need polymorph it into Element
+          const targetElement:Element = e.target as Element;
+          if (targetElement.tagName.toLowerCase() !== 'button') {
             e.preventDefault();
             isDragging = true;
             initialY = e.clientY - menu.getBoundingClientRect().top;
@@ -247,20 +255,22 @@ export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
             menu.style.top = `${offsetY}px`;
           }
         });
+        const customWindow = window as unknown as CustomWindow;
 
         document.addEventListener('mouseup', () => {
+          // need to tell typeScript to defer first because down int he script updateMenuPos is defined
           if (isDragging) {
             // Snap the menu when it is below half the screen
-            const halfScreenHeight = window.innerHeight / 2;
-            const isTopHalf = offsetY < halfScreenHeight;
+            const halfScreenHeight:number = window.innerHeight / 2;
+            const isTopHalf:boolean = offsetY < halfScreenHeight;
             if (isTopHalf) {
               menu.style.removeProperty('bottom');
               menu.style.top = '0';
-              window.updateMenuPos(vars.MENU_POSITION.top);
+              (customWindow).updateMenuPos(vars.MENU_POSITION.top);
             } else {
               menu.style.removeProperty('top');
               menu.style.bottom = '0';
-              window.updateMenuPos(vars.MENU_POSITION.bottom);
+              (customWindow).updateMenuPos(vars.MENU_POSITION.top);
             }
 
             isDragging = false;
@@ -274,7 +284,7 @@ export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
         const button = document.createElement('button');
         button.innerText = 'Scan this page';
         button.addEventListener('click', async () => {
-          await window.handleOnScanClick();
+          customWindow.handleOnScanClick();
         });
 
         menu.appendChild(p);
@@ -333,7 +343,7 @@ export const addOverlayMenu = async (page, urlsCrawled, menuPos) => {
         } else if (document.head) {
           // The <head> element exists
           // Append the variable below the head
-          head.insertAdjacentElement('afterend', shadowHost);
+          document.head.insertAdjacentElement('afterend', shadowHost);
         } else {
           // Neither <body> nor <head> nor <html> exists
           // Append the variable to the document
@@ -406,8 +416,10 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
     }
   });
 
+  type handleOnScanClickFunction = () => void;
+
   // Window functions exposed in browser
-  const handleOnScanClick = async () => {
+  const handleOnScanClick: handleOnScanClickFunction = async () => {
     log('Scan: click detected');
     try {
       await removeOverlayMenu(page);
@@ -421,17 +433,20 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
           updateMenu(pagesDict[k].page, processPageParams.urlsCrawled);
         });
     } catch (error) {
-      log('Scan: failed', error);
+      log(`Scan failed ${error}`);
     }
   };
   await page.exposeFunction('handleOnScanClick', handleOnScanClick);
+  
+  type UpdateMenuPosFunction = (newPos: any) => void;
 
-  const updateMenuPos = newPos => {
-    const prevPos = menuPos;
-    if (prevPos !== newPos) {
-      log(`Overlay menu: position updated from ${prevPos} to ${newPos}`);
-      menuPos = newPos;
-    }
+  // Define the updateMenuPos function
+  const updateMenuPos: UpdateMenuPosFunction = (newPos) => {
+      const prevPos = menuPos;
+      if (prevPos !== newPos) {
+          console.log(`Overlay menu: position updated from ${prevPos} to ${newPos}`);
+          menuPos = newPos;
+      }
   };
   await page.exposeFunction('updateMenuPos', updateMenuPos);
 

--- a/src/crawlers/pdfScanFunc.ts
+++ b/src/crawlers/pdfScanFunc.ts
@@ -8,11 +8,58 @@ import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
 import { getPageFromContext } from '../screenshotFunc/pdfScreenshotFunc.js';
-import { ensureDirSync } from 'fs-extra';
 
 const require = createRequire(import.meta.url);
 
 // CONSTANTS
+
+// Classes
+class TranslatedObject {
+  goodToFix: {
+    rules: any; // You can specify the type for rules if known
+    totalItems: number;
+  };
+  mustFix: {
+    rules: any; // You can specify the type for rules if known
+    totalItems: number;
+  };
+  needsReview: {
+    rules: any; // You can specify the type for rules if known
+    totalItems: number;
+  };
+  url: string = '';
+  pageTitle: string = '';
+  filePath: string = '';
+  totalItems: number = 0;
+
+  constructor() {
+    this.goodToFix = {
+      rules: {},
+      totalItems: 0
+    };
+    this.mustFix = {
+      rules: {},
+      totalItems: 0
+    };
+    this.needsReview = {
+      rules: {},
+      totalItems: 0
+    };
+  }
+}
+class TransformedRuleObject {
+  description: string;
+  totalItems: number;
+  conformance: string[];
+  items: { message: string; page: string; context: any; }[];
+
+  constructor() {
+    this.description = '';
+    this.totalItems = 0;
+    this.conformance = [];
+    this.items = [];
+  }
+}
 
 // AAA: 1.4.8, 2.4.9
 // AA: 1.3.4, 1.4.3, 1.4.4, 1.4.10
@@ -183,21 +230,7 @@ export const mapPdfScanResults = async (randomToken, uuidToUrlMapping) => {
 
   // loop through all jobs
   for (let jobIdx = 0; jobIdx < jobs.length; jobIdx++) {
-    const translated = {
-      // transformed result for current job
-      goodToFix: {
-        rules: {},
-        totalItems: 0,
-      },
-      mustFix: {
-        rules: {},
-        totalItems: 0,
-      },
-      needsReview: {
-        rules: {},
-        totalItems: 0,
-      },
-    };
+    const translated = new TranslatedObject();
 
     const { itemDetails, validationResult } = jobs[jobIdx];
     const { name: fileName } = itemDetails;
@@ -247,9 +280,9 @@ export const mapPdfScanResults = async (randomToken, uuidToUrlMapping) => {
   return resultsList;
 };
 
-const transformRule = async (rule, filePath) => {
+const transformRule = async (rule, filePath): Promise<[string, TransformedRuleObject]> => {
   // get specific rule
-  const transformed = {};
+  const transformed = new TransformedRuleObject;
   const { specification, description, clause, testNumber, checks } = rule;
 
   transformed.description = description;

--- a/src/crawlers/pdfScanFunc.ts
+++ b/src/crawlers/pdfScanFunc.ts
@@ -71,7 +71,6 @@ const getVeraExecutable = () => {
 const getVeraProfile = () => {
   const veraPdfProfile = globSync('**/verapdf/**/WCAG-21.xml', {
     absolute: true,
-    recursive: true,
     nodir: true,
   });
 
@@ -93,11 +92,11 @@ const isPDF = buffer => {
 
 export const handlePdfDownload = (randomToken, pdfDownloads, request, sendRequest, urlsCrawled) => {
   const pdfFileName = randomUUID();
-  const trimmedUrl = request.url.trim();
-  const pageTitle = decodeURI(trimmedUrl).split('/').pop();
+  const url:string = request.url
+  const pageTitle = decodeURI(request.url).split('/').pop();
 
   pdfDownloads.push(
-    new Promise(async resolve => {
+    new Promise<void>(async resolve => {
       const pdfResponse = await sendRequest({ responseType: 'buffer', isStream: true });
       pdfResponse.setEncoding('binary');
 
@@ -119,20 +118,20 @@ export const handlePdfDownload = (randomToken, pdfDownloads, request, sendReques
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
           });
-          urlsCrawled.scanned.push({ url: trimmedUrl, pageTitle });
+          urlsCrawled.scanned.push({ url: url, pageTitle });
         } else {
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
           });
-          urlsCrawled.invalid.push(trimmedUrl);
+          urlsCrawled.invalid.push(url);
         }
         resolve();
       });
     }),
   );
 
-  return { pdfFileName, trimmedUrl };
+  return { pdfFileName, url };
 };
 
 export const runPdfScan = async randomToken => {
@@ -171,7 +170,7 @@ export const mapPdfScanResults = async (randomToken, uuidToUrlMapping) => {
   const intermediateResultPath = `${intermediateFolder}/${constants.pdfScanResultFileName}`;
 
   const rawdata = fs.readFileSync(intermediateResultPath);
-  const output = JSON.parse(rawdata);
+  const output = JSON.parse(rawdata.toString());
 
   const errorMeta = require('../constants/errorMeta.json');
 

--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -8,30 +8,62 @@ import constants, {
 } from '../constants/constants.js';
 import { DEBUG, initNewPage, log } from './custom/utils.js';
 import { guiInfoLog } from '../logs.js';
+import {ViewportSettingsClass} from "../combine.js"
+import { UrlsCrawled } from '../constants/constants.js';
+
+// Export of classes
+
+export class ProcessPageParams{
+  scannedIdx:number;
+  blacklistedPatterns:string[] | null;
+  includeScreenshots:boolean;
+  dataset:any;
+  intermediateScreenshotsPath:string;
+  urlsCrawled:UrlsCrawled;
+  randomToken:string;
+  constructor(
+    scannedIdx: number,
+    blacklistedPatterns: string[] | null,
+    includeScreenshots: boolean,
+    dataset: any,
+    intermediateScreenshotsPath: string,
+    urlsCrawled: UrlsCrawled,
+    randomToken: string
+  ) {
+    this.scannedIdx = scannedIdx;
+    this.blacklistedPatterns = blacklistedPatterns;
+    this.includeScreenshots = includeScreenshots;
+    this.dataset = dataset;
+    this.intermediateScreenshotsPath = intermediateScreenshotsPath;
+    this.urlsCrawled = urlsCrawled;
+    this.randomToken = randomToken;
+  }
+}
+
 
 const runCustom = async (
-  url,
-  randomToken,
-  viewportSettings,
-  blacklistedPatterns,
-  includeScreenshots,
+  url:string,
+  randomToken:string,
+  viewportSettings:ViewportSettingsClass,
+  blacklistedPatterns:string[] | null,
+  includeScreenshots: boolean,
 ) => {
   // checks and delete datasets path if it already exists
   await cleanUp(randomToken);
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
-  const urlsCrawled = { ...constants.urlsCrawledObj };
+  const urlsCrawled:UrlsCrawled = { ...constants.urlsCrawledObj };
   const { dataset } = await createCrawleeSubFolders(randomToken);
   const intermediateScreenshotsPath = getIntermediateScreenshotsPath(randomToken);
-  const processPageParams = {
-    scannedIdx: 0,
+  const processPageParams = new ProcessPageParams(
+    0, // scannedIdx
     blacklistedPatterns,
     includeScreenshots,
     dataset,
     intermediateScreenshotsPath,
     urlsCrawled,
     randomToken,
-  };
+  );
 
   const pagesDict = {};
   const pageClosePromises = [];
@@ -75,11 +107,11 @@ const runCustom = async (
 
     await allPagesClosedPromise(pageClosePromises);
   } catch (error) {
-    log('PLAYWRIGHT EXECUTION ERROR', error);
+    log(`PLAYWRIGHT EXECUTION ERROR ${error}`);
     process.exit(1);
   }
 
-  guiInfoLog(guiInfoStatusTypes.COMPLETED);
+  guiInfoLog(guiInfoStatusTypes.COMPLETED,{});
   return urlsCrawled;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ const runScan = async (answers: Answers) => {
   answers.fileTypes = 'html-only';
   answers.metadata = '{}';
 
-  const data = await prepareData(answers);
+  const data:Data = await prepareData(answers);
   data.userDataDirectory = getClonedProfilesWithRandomToken(data.browser, data.randomToken);
 
   setHeadlessMode(data.browser, data.isHeadless);

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -15,6 +15,7 @@ import { createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js'
 import { generateArtifacts } from './mergeAxeResults.js';
 import { takeScreenshotForHTMLElements } from './screenshotFunc/htmlScreenshotFunc.js';
 import { silentLogger } from './logs.js';
+import { alertMessageOptions } from './constants/cliFunctions.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -179,7 +180,7 @@ export const init = async (
     scanDetails.urlsCrawled = urlsCrawled;
 
     if (urlsCrawled.scanned.length === 0) {
-      printMessage([`No pages were scanned.`], constants.alertMessageOptions);
+      printMessage([`No pages were scanned.`], alertMessageOptions);
     } else {
       await createDetailsAndLogs(scanDetails, randomToken);
       await createAndUpdateResultsFolders(randomToken);

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -182,7 +182,7 @@ export const init = async (
     if (urlsCrawled.scanned.length === 0) {
       printMessage([`No pages were scanned.`], alertMessageOptions);
     } else {
-      await createDetailsAndLogs(scanDetails, randomToken);
+      await createDetailsAndLogs(randomToken);
       await createAndUpdateResultsFolders(randomToken);
       const pagesNotScanned = [
         ...scanDetails.urlsCrawled.error,

--- a/src/static/ejs/partials/components/pagesScannedModal.ejs
+++ b/src/static/ejs/partials/components/pagesScannedModal.ejs
@@ -9,7 +9,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title fw-bold" id="pagesScannedModalLabel">
-          <%= isCustomFlow ? customFlowLabel + ' (' + totalPagesScanned + ' pages)' : scanType + ' crawl' + ' (' + totalPagesScanned + ' pages)'%>
+          NA
         </h4>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
@@ -28,7 +28,7 @@
               aria-selected="true"
             > 
               Scanned
-              <span class="badge"><%= totalPagesScanned %></span>
+              <span class="badge" id="totalPagesScannedLabel">NA</span>
             </button>
           </li>
           <li class="nav-item" role="presentation">
@@ -47,45 +47,19 @@
                 <path d="M10.8772 15.3751C10.8772 15.2274 10.9063 15.0811 10.9628 14.9446C11.0194 14.8081 11.1022 14.6841 11.2067 14.5796C11.3112 14.4752 11.4352 14.3923 11.5717 14.3357C11.7082 14.2792 11.8545 14.2501 12.0022 14.2501C12.1499 14.2501 12.2962 14.2792 12.4327 14.3357C12.5692 14.3923 12.6932 14.4752 12.7977 14.5796C12.9022 14.6841 12.985 14.8081 13.0416 14.9446C13.0981 15.0811 13.1272 15.2274 13.1272 15.3751C13.1272 15.6735 13.0087 15.9596 12.7977 16.1706C12.5867 16.3816 12.3006 16.5001 12.0022 16.5001C11.7038 16.5001 11.4177 16.3816 11.2067 16.1706C10.9957 15.9596 10.8772 15.6735 10.8772 15.3751ZM10.9874 8.61949C10.9725 8.47756 10.9875 8.33407 11.0315 8.19832C11.0756 8.06257 11.1477 7.9376 11.2432 7.83152C11.3387 7.72544 11.4554 7.64062 11.5857 7.58256C11.7161 7.52449 11.8572 7.49449 11.9999 7.49449C12.1427 7.49449 12.2838 7.52449 12.4142 7.58256C12.5445 7.64062 12.6612 7.72544 12.7567 7.83152C12.8522 7.9376 12.9243 8.06257 12.9683 8.19832C13.0124 8.33407 13.0274 8.47756 13.0124 8.61949L12.6187 12.5649C12.6055 12.7199 12.5346 12.8642 12.42 12.9695C12.3054 13.0747 12.1555 13.133 11.9999 13.133C11.8444 13.133 11.6945 13.0747 11.5799 12.9695C11.4653 12.8642 11.3944 12.7199 11.3812 12.5649L10.9874 8.61949Z" fill="#D7260F"/>
               </svg>
               Not scanned
-              <span class="badge"><%= totalPagesNotScanned %></span>
+              <span class="badge" id="totalPagesNotScannedLabel">NA</span>
             </button>
           </li>
         </ul>
         <% } %>
         <div class="tab-content">
           <div class="tab-pane fade show active" id="pages-scanned" role="tabpanel" aria-labelledby="pages-scanned-tab">
-            <ul class="unbulleted-list">
-              <% pagesScanned.forEach((page, index) => { %> 
-              <li>
-                <% if (isCustomFlow) {%>
-                    <div class="custom-flow-screenshot-container">
-                      <img 
-                        src="<%= page.pageImagePath %>" 
-                        alt="Screenshot of <%= page.url %>"
-                        class="custom-flow-screenshot"
-                        onerror="this.onerror = null; this.remove();"
-                      >
-                      <div class="display-url-container">
-                        <a href="<%= page.url %>" target="_blank"><%= page.pageTitle.length > 0 ? page.pageTitle : page.url %></a>
-                        <p><%= page.url %></p>
-                      </div>
-                    </div>
-                <% } else { %>
-                    <a href="<%= page.url %>" target="_blank"><%= page.pageTitle.length > 0 ? page.pageTitle : page.url %></a>
-                    <p><%= page.url %></p>
-                <% } %>
-              </li>
-              <% }) %>
+            <ul class="unbulleted-list" id="pagesScannedList">
             </ul>    
           </div>
           <% if (totalPagesNotScanned > 0) { %>
           <div class="tab-pane fade" id="pages-not-scanned" role="tabpanel" aria-labelledby="pages-not-scanned-tab">
-            <ul class="unbulleted-list">
-              <% pagesNotScanned.forEach((page, index) => { %>
-              <li>
-                <a class="not-scanned-url" href="<%= page.url %>" target="_blank"><%= page.url %></a>
-              </li>
-              <% }) %>
+            <ul class="unbulleted-list" id="pagesNotScannedList">
             </ul>
           </div>
           <% } %>

--- a/src/static/ejs/partials/components/scanAbout.ejs
+++ b/src/static/ejs/partials/components/scanAbout.ejs
@@ -17,7 +17,7 @@
           fill="#CED4DA"
         />
       </svg>
-      <span id="aboutStartTime"><%- unescape(formatAboutStartTime(startTime)) %></span>
+      <span id="aboutStartTime">NA</span>
     </li>
     <li>
       <svg
@@ -35,7 +35,7 @@
           fill="#CED4DA"
         />
       </svg>
-      <a href="<%= urlScanned %>" target="_blank"><%= urlScanned %></a>
+      <a id="urlScanned" href="NA" target="_blank">NA</a>
     </li>
     <% if (viewport !== null) { %>
       <li>
@@ -86,8 +86,8 @@
           />
         </svg>
         <% } %>
-          <%= viewport.startsWith("CustomWidth") ? `${viewport.split("_")[1]} width` : viewport %>
-          viewport 
+        <span id="viewport">
+           NA
         </span>
       </li>
     <% } %>
@@ -141,7 +141,7 @@
         id="pagesScannedModalToggle"
         data-bs-toggle="modal"
         data-bs-target="#pagesScannedModal"
-        ><%= isCustomFlow ? customFlowLabel + ' (' + totalPagesScanned + ' ' + (totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanType + ' crawl' + ' (' + totalPagesScanned + ' ' + (totalPagesScanned === 1 ? 'page' : 'pages') + ')'%>
+        >NA
       <% if (totalPagesNotScanned > 0) { %>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
           <path d="M12 19.875C9.91142 19.875 7.90838 19.0453 6.43153 17.5685C4.95468 16.0916 4.125 14.0886 4.125 12C4.125 9.91142 4.95468 7.90838 6.43153 6.43153C7.90838 4.95468 9.91142 4.125 12 4.125C14.0886 4.125 16.0916 4.95468 17.5685 6.43153C19.0453 7.90838 19.875 9.91142 19.875 12C19.875 14.0886 19.0453 16.0916 17.5685 17.5685C16.0916 19.0453 14.0886 19.875 12 19.875ZM12 21C14.3869 21 16.6761 20.0518 18.364 18.364C20.0518 16.6761 21 14.3869 21 12C21 9.61305 20.0518 7.32387 18.364 5.63604C16.6761 3.94821 14.3869 3 12 3C9.61305 3 7.32387 3.94821 5.63604 5.63604C3.94821 7.32387 3 9.61305 3 12C3 14.3869 3.94821 16.6761 5.63604 18.364C7.32387 20.0518 9.61305 21 12 21Z" fill="#D7260F"/>
@@ -196,9 +196,8 @@
           </clipPath>
         </defs>
       </svg>
-      <span>
-        <%= items.mustFix.totalItems + items.goodToFix.totalItems  %> <%= (items.mustFix.totalItems + items.goodToFix.totalItems === 1 ? 'occurrence' : 'occurrences') %> failed,<br>
-        <%= items.passed.totalItems %> <%= (items.passed.totalItems === 1 ? 'occurrence' : 'occurrences') %> passed
+      <span id="items">
+        NA
         <svg
           tabindex="-1"
           id="passedItemsTooltip"
@@ -242,13 +241,13 @@
         <rect x="-291" y="-101" width="1451" height="1409" fill="#B5C5CA"/>
         </g>
       </svg>
-      <span><%= 'Purple A11y Version ' + phAppVersion %></span>
+      <span id="phAppVersion">NA</span>
     </li>
     <% if (cypressScanAboutMetadata) { %>
       <% const metadataItems = Object.keys(cypressScanAboutMetadata); %>
       <% metadataItems.forEach((key) => { %>
         <li>
-          <span><%= key[0].toUpperCase() + key.slice(1) + ': ' + cypressScanAboutMetadata[key] %></span>
+          <span id = "cypressScanAboutMetadata">NA</span>
         </li>
       <% }) %>  
     <% } %>

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -18,20 +18,6 @@
     />
     <%- include('partials/styles/bootstrap') %> <%- include('partials/styles/highlightjs') %> <%-
     include('partials/styles/styles') %>
-
-    <script>
-      const scanItems = <%- JSON.stringify(
-          {
-            ...items,
-            passed: {
-              rules: items.passed.rules.map(r => delete r.pagesAffected),
-              ...items.passed
-            },
-          }
-        ) %>;
-
-      const startTime = <%- JSON.stringify(startTime) %>
-    </script>
   </head>
 
   <body class="d-flex flex-column">
@@ -55,9 +41,162 @@
         });
       }
 
-      const initAboutStartTime = () => {
-        const formattedViewerLocalStartTime = formatAboutStartTime(startTime);
+      // Scan DATA FUNCTION TO REPLACE NA
+      const scanDataWCAGCompliance = () => {
+        const wcagComplianceCard = document.querySelector("#wcag-compliance-card")
+        const passPecentage = wcagComplianceCard.querySelector('[aria-label="Pass percentage"]')
+        passPecentage.innerHTML = scanData.wcagPassPercentage+"%";
+        const wcagBarProgess = wcagComplianceCard.querySelector(".wcag-compliance-passes-bar-progress");
+        wcagBarProgess.style.width = `${scanData.wcagPassPercentage}%`; // Set this to your desired width
+      };
+
+      const scanDataTop5Card = () => {
+          const card = document.getElementById("top-five-card");
+          const list = card.querySelector(".unbulleted-list");
+
+          // Sort the items based on totalIssues in descending order
+          const sortedTop5 = scanData.topFiveMostIssues.sort((a, b) => b.totalIssues - a.totalIssues);
+          let i = 0;
+          for (i < 5; i++;) {
+              const page = sortedTop5[i];
+              if (page.totalIssues !== 0) {
+                  const listItem = document.createElement('li');
+                  listItem.className = "d-flex justify-content-between";
+
+                  const link = document.createElement('a');
+                  link.href = page.url;
+                  link.target = "_blank";
+                  link.textContent = page.pageTitle.length > 0 ? page.pageTitle : page.url;
+
+                  const issueCount = document.createElement('span');
+                  issueCount.className = "fw-bold ms-2";
+                  issueCount.setAttribute('aria-label', `${page.totalIssues} issues`);
+                  issueCount.textContent = page.totalIssues;
+
+                  listItem.appendChild(link);
+                  listItem.appendChild(issueCount);
+
+                  list.appendChild(listItem);
+              }
+          }
+      };
+
+      const scanDataCategorySelector = () =>{
+        function generateCategorySummary(category, items) {
+          let summary = '';
+
+          if (category !== 'passed' && items[category].totalItems !== 0) {
+              summary = `${items[category].rules.length} ${items[category].rules.length === 1 ? 'issue' : 'issues'} / ${items[category].totalItems} ${items[category].totalItems === 1 ? 'occurrence' : 'occurrences'}`;
+          } else if (category !== 'passed' && items[category].totalItems === 0) {
+              summary = '0 issues';
+          } else {
+              summary = `${items[category].totalItems} ${items[category].totalItems === 1 ? 'occurrence' : 'occurrences'}`;
+          }
+
+          return summary;
+        }
+        const nav = document.querySelector("nav");
+        const divs = nav.querySelectorAll(":scope > div");
+
+        divs.forEach(div => {
+          let spanCategoryInformation = div.querySelector(".category-information");
+          let category = spanCategoryInformation.id.replace("ItemsInformation", "");
+
+          let summary = generateCategorySummary(category,scanItems)
+          spanCategoryInformation.innerHTML = summary;
+
+      });
+
+        
+      }
+
+
+      const scanDataHTML = () => {
+        const formattedViewerLocalStartTime = formatAboutStartTime(scanData.startTime);
         document.getElementById('aboutStartTime').innerHTML = formattedViewerLocalStartTime;
+        document.getElementById('urlScanned').innerHTML = scanData.urlScanned;
+        document.getElementById('urlScanned').href = scanData.urlScanned;
+        document.getElementById('viewport').innerHTML = scanData.viewport.startsWith("CustomWidth") ? `${scanData.viewport.split("_")[1]} width viewport` : scanData.viewport + ' viewport';
+        document.getElementById('pagesScannedModalToggle').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
+
+        var itemsElement = document.getElementById('items');
+        var failedItems = scanItems.mustFix.totalItems + scanItems.goodToFix.totalItems;
+        var passedItems = scanItems.passed.totalItems;
+        var itemsContent = `${failedItems} ${failedItems === 1 ? 'occurrence' : 'occurrences'} failed,<br>${passedItems} ${passedItems === 1 ? 'occurrence' : 'occurrences'} passed`;
+        itemsElement.innerHTML = itemsContent;
+ 
+        var phAppVersionElement = document.getElementById('phAppVersion');
+        var versionContent = 'Purple A11y Version ' + scanData.phAppVersion;
+        phAppVersionElement.innerHTML = versionContent;
+
+        var isCustomFlow = scanData.isCustomFlow; 
+        var pagesScanned = scanData.pagesScanned;
+        var pagesScannedList = document.getElementById('pagesScannedList');
+
+        pagesScanned.forEach((page, index) => {
+          var listItem = document.createElement('li');
+
+          if (isCustomFlow) {
+            listItem.innerHTML = `
+              <div class="custom-flow-screenshot-container">
+                <img 
+                  src="${page.pageImagePath}" 
+                  alt="Screenshot of ${page.url}"
+                  class="custom-flow-screenshot"
+                  onerror="this.onerror = null; this.remove();"
+                >
+                <div class="display-url-container">
+                  <a href="${page.url}" target="_blank">${page.pageTitle.length > 0 ? page.pageTitle : page.url}</a>
+                  <p>${page.url}</p>
+                </div>
+              </div>
+            `;
+          } else {
+            listItem.innerHTML = `
+              <a href="${page.url}" target="_blank">${page.pageTitle.length > 0 ? page.pageTitle : page.url}</a>
+              <p>${page.url}</p>
+            `;
+          }
+
+          pagesScannedList.appendChild(listItem);
+        });
+
+        var totalPagesNotScanned = scanData.totalPagesNotScanned; 
+        var pagesNotScanned = scanData.pagesNotScanned;
+
+        var pagesNotScannedList = document.getElementById('pagesNotScannedList');
+
+        // Only update if there are pages not scanned
+        if (totalPagesNotScanned > 0) {
+          document.getElementById('totalPagesScannedLabel').innerHTML = scanData.totalPagesScanned;
+          document.getElementById('totalPagesNotScannedLabel').innerHTML = scanData.totalPagesNotScanned;
+
+          pagesNotScanned.forEach((page, index) => {
+            var listItem = document.createElement('li');
+            listItem.innerHTML = `<a class="not-scanned-url" href="${page.url}" target="_blank">${page.url}</a>`;
+            pagesNotScannedList.appendChild(listItem);
+          });
+        }
+
+        // For rest of the page that is not content
+        scanDataWCAGCompliance();
+        scanDataTop5Card();
+        scanDataCategorySelector();
+
+        const cypressScanAboutMetadata = scanData.cypressScanAboutMetadata;
+        if (cypressScanAboutMetadata) {
+          const metadataItems = Object.keys(cypressScanAboutMetadata);
+          metadataItems.forEach((key) => {
+            var metadataSpan = document.getElementById('cypressScanAboutMetadata');
+            if (metadataSpan) {
+              metadataSpan.innerHTML = key[0].toUpperCase() + key.slice(1) + ': ' + cypressScanAboutMetadata[key];
+            }
+          });
+        }
+
+        document.getElementById('pagesScannedModalLabel').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
+
+
       };
 
       const formatAboutStartTime = dateString => {
@@ -89,7 +228,7 @@
 
       document.addEventListener('DOMContentLoaded', () => {
         initTooltips();
-        initAboutStartTime();
+        scanDataHTML();
       });
     </script>
     <!-- Checks if js runs -->

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,12 +43,11 @@ export const getStoragePath = (randomToken: string): string => {
   }
 };
 
-export const createDetailsAndLogs = async (scanDetails, randomToken) => {
+export const createDetailsAndLogs = async (randomToken) => {
   const storagePath = getStoragePath(randomToken);
   const logPath = `logs/${randomToken}`;
   try {
     await fs.ensureDir(storagePath);
-    await fs.writeFile(`${storagePath}/details.json`, JSON.stringify(scanDetails,null, 2));
 
     // update logs
     await fs.ensureDir(logPath);
@@ -125,7 +124,6 @@ export const createAndUpdateResultsFolders = async randomToken => {
   const storagePath = getStoragePath(randomToken);
   await fs.ensureDir(`${storagePath}/reports`);
 
-  const intermediateDatasetsPath = `${randomToken}/datasets/${randomToken}`;
   const intermediatePdfResultsPath = `${randomToken}/${constants.pdfScanResultFileName}`;
 
   const transferResults = async (intermPath, resultFile) => {
@@ -148,7 +146,6 @@ export const createAndUpdateResultsFolders = async randomToken => {
   };
 
   await Promise.all([
-    transferResults(intermediateDatasetsPath, constants.allIssueFileName),
     transferResults(intermediatePdfResultsPath, constants.pdfScanResultFileName),
   ]);
 };


### PR DESCRIPTION
This PR is part of the typescript migration and adds:

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- Add type safety to `scanDetails`
- BREAKINGCHANGE! `urlsCrawledObj` is now changed to class-based `UrlsCrawled` as is its being referenced in other files as well
- import `alertMessageOptions` as its defined in `cliFunctions.ts`
- Add types for `ItemsInfo`, `PageInfo`, `RuleInfo`, `AllIssues`. Not changing `allIssues` to class-based as its only being used in `mergeAxeResults.ts` at the moment.
- Update strings in `pagesScannedModal.ejs` and `scanAbout.ejs` with NA and add ids to some divs to call the elements to change.
- Refactor the report.html to store scan metadata in base64-encoded JSON objects.
- Add functions to target a specific part of the page to update content based on the data provided by `scanData` and `scanItems` objects to replace NA.
- Move `compiledResults.json` and `passed_items.json.txt` to `reportScanData.csv` as base64 encoded strings.
- Fix an unhandled exception when a page does not respond to `page.screenshot()` on custom flow
- Fix Console prints `Preferred browser undefined` in `npm run cli`
- Bump package to `0.10.1`

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x]   I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
