### PR TITLE
Fix on sitemap and Added localFileScan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "print-message": "^3.0.1",
         "safe-regex": "^2.1.1",
         "typescript": "^5.4.5",
+        "url": "^0.11.3",
         "validator": "^13.11.0",
         "which": "^4.0.0",
         "winston": "^3.11.0",
@@ -3055,13 +3056,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3611,16 +3617,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-properties": {
@@ -3888,6 +3897,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-set-tostringtag": {
@@ -4843,14 +4871,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5109,11 +5141,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7153,7 +7185,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7814,6 +7845,20 @@
         }
       ]
     },
+    "node_modules/qs": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -8222,14 +8267,16 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8269,14 +8316,17 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8974,6 +9024,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -8982,6 +9041,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "eslint-plugin-import": "^2.27.4",
         "eslint-plugin-prettier": "^5.0.0",
         "globals": "^15.2.0",
-        "jest": "^29.3.1"
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2950,12 +2950,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4618,9 +4618,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-import": "^2.27.4",
     "eslint-plugin-prettier": "^5.0.0",
     "globals": "^15.2.0",
-    "jest": "^29.3.1"
+    "jest": "^29.7.0"
   },
   "overrides": {
     "node-fetch": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "print-message": "^3.0.1",
     "safe-regex": "^2.1.1",
     "typescript": "^5.4.5",
+    "url": "^0.11.3",
     "validator": "^13.11.0",
     "which": "^4.0.0",
     "winston": "^3.11.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -268,7 +268,7 @@ const scanInit = async (argvs: Answers): Promise<string> => {
       printMessage([statuses.systemError.message], messageOptions);
       process.exit(res.status);
     case statuses.invalidUrl.code:
-      if (argvs.scanner !== ScannerTypes.SITEMAP) {
+      if (argvs.scanner !== ScannerTypes.SITEMAP && argvs.scanner !== ScannerTypes.LOCALFILE) {
         printMessage([statuses.invalidUrl.message], messageOptions);
         process.exit(res.status);
       }

--- a/src/constants/cliFunctions.ts
+++ b/src/constants/cliFunctions.ts
@@ -16,7 +16,7 @@ export const alertMessageOptions = {
 export const cliOptions: { [key: string]: Options } = {
   c: {
     alias: 'scanner',
-    describe: 'Type of scan, 1) sitemap, 2) website crawl, 3) custom flow, 4) intelligent 5)local file',
+    describe: 'Type of scan, 1) sitemap, 2) website crawl, 3) custom flow, 4) intelligent 5) local file',
     requiresArg: true,
     coerce: option => {
       const choices = ['sitemap', 'website', 'custom', 'intelligent', 'localfile'];

--- a/src/constants/cliFunctions.ts
+++ b/src/constants/cliFunctions.ts
@@ -16,10 +16,10 @@ export const alertMessageOptions = {
 export const cliOptions: { [key: string]: Options } = {
   c: {
     alias: 'scanner',
-    describe: 'Type of scan, 1) sitemap, 2) website crawl, 3) custom flow, 4) intelligent',
+    describe: 'Type of scan, 1) sitemap, 2) website crawl, 3) custom flow, 4) intelligent 5)local file',
     requiresArg: true,
     coerce: option => {
-      const choices = ['sitemap', 'website', 'custom', 'intelligent'];
+      const choices = ['sitemap', 'website', 'custom', 'intelligent', 'localfile'];
       if (typeof option === 'number') {
         // Will also allow integer choices
         if (Number.isInteger(option) && option > 0 && option <= choices.length) {
@@ -36,6 +36,8 @@ export const cliOptions: { [key: string]: Options } = {
           return ScannerTypes.CUSTOM;
         case 'intelligent':
           return ScannerTypes.INTELLIGENT;
+        case 'localfile':
+          return ScannerTypes.LOCALFILE;
         default:
           printMessage(
             [

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1024,7 +1024,14 @@ export const getBrowserToRun = (
   preferredBrowser: BrowserTypes,
   isCli = false,
 ): { browserToRun: BrowserTypes; clonedBrowserDataDir: string } => {
+  console.log(`Preferred browser ${preferredBrowser}`);
   const platform = os.platform();
+
+  // Prioritise Chrome on Windows and Mac platforms if user does not specify a browser
+  if (!preferredBrowser && (os.platform() === 'win32' || os.platform() === 'darwin')) {
+    preferredBrowser = BrowserTypes.CHROME;
+  }
+
   if (preferredBrowser === BrowserTypes.CHROME) {
     const chromeData = getChromeData();
     if (chromeData) return chromeData;

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1025,7 +1025,7 @@ export const getBrowserToRun = (
   isCli = false,
 ): { browserToRun: BrowserTypes; clonedBrowserDataDir: string } => {
   console.log(`Preferred browser ${preferredBrowser}`);
-  
+
   const platform = os.platform();
 
   // Prioritise Chrome on Windows and Mac platforms if user does not specify a browser

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -30,7 +30,7 @@ import { silentLogger } from '../logs.js';
 import { isUrlPdf } from '../crawlers/commonCrawlerFunc.js';
 import { randomThreeDigitNumberString } from '../utils.js';
 import { Answers, Data } from '#root/index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL  } from 'url';
 
 // validateDirPath validates a provided directory path
 // returns null if no error
@@ -750,9 +750,8 @@ export const getLinksFromSitemap = async (
       ? (url = addBasicAuthCredentials(url, username, password))
       : url;
 
-    if (url.startsWith('/')) {
-      url = 'file://' + url;
-    }
+    // Convert "/" to "file:///"
+    url = convertPathToLocalFile(url);
 
     let request;
     try {
@@ -1763,4 +1762,11 @@ export function convertLocalFileToPath(url: string): string {
     url = fileURLToPath(url);
   }
   return url;
+}
+
+export function convertPathToLocalFile(filePath: string): string {
+  if (filePath.startsWith("/")){
+    filePath = pathToFileURL(filePath).toString();
+  }
+  return filePath;
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -854,7 +854,6 @@ export const getLinksFromSitemap = async (
     }
 
     scannedSitemaps.add(url);
-    console.log(url);
 
     // Check whether its a file path or a URL
     if (isFilePath(url)) {
@@ -927,15 +926,12 @@ export const getLinksFromSitemap = async (
           data = await (await instance.get(url, { timeout: 80000 })).data;
         } catch (error) {
           if (error.code === 'ECONNABORTED') {
-            console.log('here');
             await getDataUsingPlaywright();
           }
         }
       }
     } else {
-      if (url.startsWith('file://')) {
-        url = url.slice(7);
-      }
+      url = convertLocalFileToPath(url);
       data = fs.readFileSync(url, 'utf8');
     }
     const $ = cheerio.load(data, { xml: true });
@@ -1764,7 +1760,7 @@ export const isFilePath = (url: string): boolean => {
 
 export function convertLocalFileToPath(url: string): string {
   if (url.startsWith('file://')) {
-    const filePath = fileURLToPath(url);
-    return filePath;
+    url = fileURLToPath(url);
   }
+  return url;
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -30,6 +30,7 @@ import { silentLogger } from '../logs.js';
 import { isUrlPdf } from '../crawlers/commonCrawlerFunc.js';
 import { randomThreeDigitNumberString } from '../utils.js';
 import { Answers, Data } from '#root/index.js';
+import { fileURLToPath } from 'url';
 
 // validateDirPath validates a provided directory path
 // returns null if no error
@@ -1752,5 +1753,12 @@ export const waitForPageLoaded = async (page, timeout = 10000) => {
 };
 
 export const isFilePath = (url: string): boolean => {
-  return path.isAbsolute(url) && fs.existsSync(url) && fs.lstatSync(url).isFile();
+  return url.startsWith('file://') || url.startsWith('/');
+}
+
+export function convertLocalFileToPath(url: string): string {
+  if (url.startsWith('file://')) {
+    const filePath = fileURLToPath(url);
+    return filePath;
+  }
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1025,6 +1025,7 @@ export const getBrowserToRun = (
   isCli = false,
 ): { browserToRun: BrowserTypes; clonedBrowserDataDir: string } => {
   console.log(`Preferred browser ${preferredBrowser}`);
+  
   const platform = os.platform();
 
   // Prioritise Chrome on Windows and Mac platforms if user does not specify a browser

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -763,7 +763,7 @@ export const getLinksFromSitemap = async (
     if (isUrlPdf(url)) {
       request.skipNavigation = true;
     }
-    console.log("Adding URL to list:", url);
+
     urls[url] = request;
   };
 
@@ -971,23 +971,18 @@ export const getLinksFromSitemap = async (
         }
         break;
       case constants.xmlSitemapTypes.xml:
-        console.log("hi2")
         silentLogger.info(`This is a XML format sitemap.`);
         await processXmlSitemap($, sitemapType, 'loc', 'lastmod', 'url');
-        console.log("hi2.1")
         break;
       case constants.xmlSitemapTypes.rss:
-        console.log("hi3")
         silentLogger.info(`This is a RSS format sitemap.`);
         await processXmlSitemap($, sitemapType, 'link', 'pubDate', 'item');
         break;
       case constants.xmlSitemapTypes.atom:
-        console.log("hi4")
         silentLogger.info(`This is a Atom format sitemap.`);
         await processXmlSitemap($, sitemapType, 'link', 'published', 'entry');
         break;
       default:
-        console.log("hi5")
         silentLogger.info(`This is an unrecognised XML sitemap format.`);
         processNonStandardSitemap(data);
     }
@@ -999,9 +994,9 @@ export const getLinksFromSitemap = async (
     silentLogger.error(e);
   }
 
-  console.log('urls123', urls)
+
   const requestList = Object.values(urls);
-  console.log("requestList urls", requestList)
+
   return requestList;
 };
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -203,6 +203,7 @@ export enum ScannerTypes {
   WEBSITE = 'Website',
   CUSTOM = 'Custom',
   INTELLIGENT = 'Intelligent',
+  LOCALFILE = 'LocalFile',
 }
 
 export const guiInfoStatusTypes = {

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -29,6 +29,7 @@ const startScanQuestions = [
       { name: 'Website', value: ScannerTypes.WEBSITE },
       { name: 'Custom', value: ScannerTypes.CUSTOM },
       { name: 'Intelligent', value: ScannerTypes.INTELLIGENT },
+      { name: 'Localfile', value: ScannerTypes.LOCALFILE},
     ],
   },
   {
@@ -104,7 +105,7 @@ const startScanQuestions = [
         case statuses.systemError.code:
           return statuses.systemError.message;
         case statuses.invalidUrl.code:
-          if (answers.scanner !== ScannerTypes.SITEMAP) {
+          if (answers.scanner !== (ScannerTypes.SITEMAP || ScannerTypes.LOCALFILE)) {
             return statuses.invalidUrl.message;
           }
 

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -5,6 +5,7 @@ import axe from 'axe-core';
 import { axeScript, guiInfoStatusTypes, saflyIconSelector } from '../constants/constants.js';
 import { guiInfoLog } from '../logs.js';
 import { takeScreenshotForHTMLElements } from '../screenshotFunc/htmlScreenshotFunc.js';
+import { isFilePath } from '../constants/common.js';
 
 export const filterAxeResults = (results, pageTitle, customFlowDetails) => {
   const { violations, passes, incomplete, url } = results;
@@ -182,8 +183,12 @@ export const failedRequestHandler = async ({ request }) => {
 };
 
 export const isUrlPdf = url => {
-  const parsedUrl = new URL(url);
-  return /\.pdf($|\?|#)/i.test(parsedUrl.pathname) || /\.pdf($|\?|#)/i.test(parsedUrl.href);
+  if(isFilePath(url)) {
+    return /\.pdf$/i.test(url);
+  } else {
+    const parsedUrl = new URL(url);
+    return /\.pdf($|\?|#)/i.test(parsedUrl.pathname) || /\.pdf($|\?|#)/i.test(parsedUrl.href);
+  }
 };
 
 

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -163,6 +163,7 @@ const crawlLocalFile = async (
     request.url = 'file://' + request.url;
     await page.goto(request.url);
     const results = await runAxeScript(includeScreenshots, page, randomToken);
+    
     guiInfoLog(guiInfoStatusTypes.SCANNED, {
       numScanned: urlsCrawled.scanned.length,
       urlScanned: request.url,

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -76,7 +76,8 @@ const crawlLocalFile = async (
 
       // Crawl the links from the sitemap
       for (const link of linksFromSitemap) {
-        if (link.url.startsWith("file:///") ) {
+        console.log('link',link)
+        if (link.url.startsWith("file:///") || link.url.startsWith("http://") || link.url.startsWith("https://") ){
           if (link.url.endsWith('.xml')) {
             console.log(link.url,'Local sitemap file found')
             // Recursive call for local sitemap file
@@ -101,6 +102,7 @@ const crawlLocalFile = async (
             );
             console.log('Local sitemap file crawled',updatedUrlsCrawled)
             urlsCrawled = { ...urlsCrawled, ...updatedUrlsCrawled };
+            return urlsCrawled;
           } else {
             // Regular local file
             console.log(link.url,'Local file found')

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -63,15 +63,22 @@ const crawlLocalFile = async (
     }
   }
 
+  if (sitemapUrl.startsWith('file://')) {
+        sitemapUrl= sitemapUrl.slice(7);
+      }
+
   if (fs.existsSync(sitemapUrl)) {
     if (sitemapUrl.endsWith('.pdf') || sitemapUrl.endsWith('.html')) {
       // PDF or HTML file
       linksFromSitemap = [new Request({ url: sitemapUrl })];
+      // Basically need to append to linksFromSitemap, instead of just creating request here
+      console.log("HERE",linksFromSitemap, "THERE",sitemapUrl)
     } else if (sitemapUrl.endsWith('.xml')) {
       // Sitemap file
       const username = '';
       const password = '';
       console.log('Sitemap URL is an XML file');
+      //maybe need change this method
       linksFromSitemap = await getLinksFromSitemap(sitemapUrl, maxRequestsPerCrawl, browser, userDataDirectory, userUrlInputFromIntelligent, fromCrawlIntelligentSitemap, username, password);
 
       // Crawl the links from the sitemap
@@ -102,7 +109,6 @@ const crawlLocalFile = async (
             );
             console.log('Local sitemap file crawled',updatedUrlsCrawled)
             urlsCrawled = { ...urlsCrawled, ...updatedUrlsCrawled };
-            return urlsCrawled;
           } else {
             // Regular local file
             console.log(link.url,'Local file found')

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -15,6 +15,7 @@ import {
   messageOptions,
   isSkippedUrl,
   isFilePath,
+  convertLocalFileToPath,
 } from '../constants/common.js';
 import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -63,16 +64,13 @@ const crawlLocalFile = async (
     }
   }
 
-  if (
-    !(sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/')) ||
-    !fs.existsSync(sitemapUrl)
-  ) {
+  // Check if the sitemapUrl is a local file and if it exists
+  if (!(isFilePath(sitemapUrl)) || !fs.existsSync(sitemapUrl)) {
     return;
   }
 
-  if (sitemapUrl.startsWith('file://')) {
-    sitemapUrl = sitemapUrl.slice(7);
-  }
+  // Checks if its in the right file format, and change it before placing into linksFromSitemap
+  convertLocalFileToPath(sitemapUrl);
 
   if (!sitemapUrl.endsWith('.xml')) {
     // Non XMLPDF or HTML file

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -72,14 +72,14 @@ const crawlLocalFile = async (
   // Checks if its in the right file format, and change it before placing into linksFromSitemap
   convertLocalFileToPath(sitemapUrl);
 
+  // XML Files
   if (!sitemapUrl.endsWith('.xml')) {
-    // Non XMLPDF or HTML file
     linksFromSitemap = [new Request({ url: sitemapUrl })];
+    
+  // Non XML file
   } else if (sitemapUrl.endsWith('.xml')) {
-    // Sitemap file
     const username = '';
     const password = '';
-    //console.log('Sitemap URL is an XML file', sitemapUrl);
 
     // Put it to crawlSitemap function to handle xml files
     const updatedUrlsCrawled = await crawlSitemap(
@@ -101,7 +101,7 @@ const crawlLocalFile = async (
       (urlsCrawledFromIntelligent = null), //optional
       true,
     );
-    //console.log('Local sitemap file crawled', updatedUrlsCrawled);
+    
     urlsCrawled = { ...urlsCrawled, ...updatedUrlsCrawled };
     return urlsCrawled;
   }

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -63,85 +63,49 @@ const crawlLocalFile = async (
     }
   }
 
+  if (
+    !(sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/')) ||
+    !fs.existsSync(sitemapUrl)
+  ) {
+    return;
+  }
+
   if (sitemapUrl.startsWith('file://')) {
-        sitemapUrl= sitemapUrl.slice(7);
-      }
+    sitemapUrl = sitemapUrl.slice(7);
+  }
 
-  if (fs.existsSync(sitemapUrl)) {
-    if (sitemapUrl.endsWith('.pdf') || sitemapUrl.endsWith('.html')) {
-      // PDF or HTML file
-      linksFromSitemap = [new Request({ url: sitemapUrl })];
-      // Basically need to append to linksFromSitemap, instead of just creating request here
-      console.log("HERE",linksFromSitemap, "THERE",sitemapUrl)
-    } else if (sitemapUrl.endsWith('.xml')) {
-      // Sitemap file
-      const username = '';
-      const password = '';
-      console.log('Sitemap URL is an XML file');
-      //maybe need change this method
-      linksFromSitemap = await getLinksFromSitemap(sitemapUrl, maxRequestsPerCrawl, browser, userDataDirectory, userUrlInputFromIntelligent, fromCrawlIntelligentSitemap, username, password);
+  if (!sitemapUrl.endsWith('.xml')) {
+    // Non XMLPDF or HTML file
+    linksFromSitemap = [new Request({ url: sitemapUrl })];
+  } else if (sitemapUrl.endsWith('.xml')) {
+    // Sitemap file
+    const username = '';
+    const password = '';
+    //console.log('Sitemap URL is an XML file', sitemapUrl);
 
-      // Crawl the links from the sitemap
-      for (const link of linksFromSitemap) {
-        console.log('link',link)
-        if (link.url.startsWith("file:///") || link.url.startsWith("http://") || link.url.startsWith("https://") ){
-          if (link.url.endsWith('.xml')) {
-            console.log(link.url,'Local sitemap file found')
-            // Recursive call for local sitemap file
-            const updatedUrlsCrawled = await crawlSitemap(
-              link.url,
-              randomToken,
-              host,
-              viewportSettings,
-              maxRequestsPerCrawl, 
-              browser,
-              userDataDirectory,
-              specifiedMaxConcurrency,
-              fileTypes,
-              blacklistedPatterns,
-              includeScreenshots,
-              extraHTTPHeaders,
-              fromCrawlIntelligentSitemap = false, //optional
-              userUrlInputFromIntelligent = null, //optional
-              datasetFromIntelligent = null, //optional
-              urlsCrawledFromIntelligent = null, //optional
-              
-            );
-            console.log('Local sitemap file crawled',updatedUrlsCrawled)
-            urlsCrawled = { ...urlsCrawled, ...updatedUrlsCrawled };
-          } else {
-            // Regular local file
-            console.log(link.url,'Local file found')
-            const updatedUrlsCrawled = await crawlLocalFile(
-              link.url,
-              randomToken,
-              host,
-              viewportSettings,
-              maxRequestsPerCrawl,
-              browser,
-              userDataDirectory,
-              specifiedMaxConcurrency,
-              fileTypes,
-              blacklistedPatterns,
-              includeScreenshots,
-              extraHTTPHeaders,
-              true,
-              userUrlInputFromIntelligent,
-              dataset,
-              urlsCrawled
-            );
-            console.log("localFile",updatedUrlsCrawled)
-            urlsCrawled = { ...urlsCrawled, ...updatedUrlsCrawled };
-          }
-        }
-      }
-    } else {
-      // Unsupported file type
-      throw new Error(`Unsupported file type: ${sitemapUrl}`);
-    }
-  } else {
-    // File not found
-    throw new Error(`File not found: ${sitemapUrl}`);
+    // Put it to crawlSitemap function to handle xml files
+    const updatedUrlsCrawled = await crawlSitemap(
+      sitemapUrl,
+      randomToken,
+      host,
+      viewportSettings,
+      maxRequestsPerCrawl,
+      browser,
+      userDataDirectory,
+      specifiedMaxConcurrency,
+      fileTypes,
+      blacklistedPatterns,
+      includeScreenshots,
+      extraHTTPHeaders,
+      (fromCrawlIntelligentSitemap = false), //optional
+      (userUrlInputFromIntelligent = null), //optional
+      (datasetFromIntelligent = null), //optional
+      (urlsCrawledFromIntelligent = null), //optional
+      true,
+    );
+    //console.log('Local sitemap file crawled', updatedUrlsCrawled);
+    urlsCrawled = { ...urlsCrawled, ...updatedUrlsCrawled };
+    return urlsCrawled;
   }
 
   try {

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -1,165 +1,160 @@
 import crawlee, { Request } from 'crawlee';
- import printMessage from 'print-message';
- import {
-     createCrawleeSubFolders,
-     preNavigationHooks,
-     runAxeScript,
-     failedRequestHandler,
-     isUrlPdf,
- } from './commonCrawlerFunc.js';
+import printMessage from 'print-message';
+import {
+  createCrawleeSubFolders,
+  preNavigationHooks,
+  runAxeScript,
+  failedRequestHandler,
+  isUrlPdf,
+} from './commonCrawlerFunc.js';
 
- import constants, { guiInfoStatusTypes, basicAuthRegex } from '../constants/constants.js';
- import {
-     getLinksFromSitemap,
-     getPlaywrightLaunchOptions,
-     messageOptions,
-     isSkippedUrl,
- } from '../constants/common.js';
- import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
- import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
- import fs from 'fs';
- import { guiInfoLog } from '../logs.js';
- import playwright from 'playwright';
- import path from 'path';
+import constants, { guiInfoStatusTypes, basicAuthRegex } from '../constants/constants.js';
+import {
+  getLinksFromSitemap,
+  getPlaywrightLaunchOptions,
+  messageOptions,
+  isSkippedUrl,
+} from '../constants/common.js';
+import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
+import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
+import fs from 'fs';
+import { guiInfoLog } from '../logs.js';
+import playwright from 'playwright';
+import path from 'path';
 
- const crawlLocalFile = async (
-     sitemapUrl,
-     randomToken,
-     host,
-     viewportSettings,
-     maxRequestsPerCrawl,
-     browser,
-     userDataDirectory,
-     specifiedMaxConcurrency,
-     fileTypes,
-     blacklistedPatterns,
-     includeScreenshots,
-     extraHTTPHeaders,
-     fromCrawlIntelligentSitemap = false, //optional
-     userUrlInputFromIntelligent = null, //optional
-     datasetFromIntelligent = null, //optional
-     urlsCrawledFromIntelligent = null, //optional
+const crawlLocalFile = async (
+  sitemapUrl: string,
+  randomToken: string,
+  host: string,
+  viewportSettings: any,
+  maxRequestsPerCrawl: number,
+  browser: string,
+  userDataDirectory: string,
+  specifiedMaxConcurrency: number,
+  fileTypes: string,
+  blacklistedPatterns: string[],
+  includeScreenshots: boolean,
+  extraHTTPHeaders: any,
+  fromCrawlIntelligentSitemap: boolean = false, //optional
+  userUrlInputFromIntelligent: any = null, //optional
+  datasetFromIntelligent: any = null, //optional
+  urlsCrawledFromIntelligent: any = null, //optional
+) => {
+  let dataset: any;
+  let urlsCrawled: any;
+  let linksFromSitemap: Request[] = [];
 
- ) => {
-     let dataset;
-     let urlsCrawled;
-     let linksFromSitemap
+  // Boolean to omit axe scan for basic auth URL
+  let isBasicAuth: boolean;
+  let basicAuthPage: number = 0;
+  let finalLinks: Request[] = [];
 
-     // Boolean to omit axe scan for basic auth URL
-     let isBasicAuth;
-     let basicAuthPage = 0;
-     let finalLinks = [];
+  if (fromCrawlIntelligentSitemap) {
+    dataset = datasetFromIntelligent;
+    urlsCrawled = urlsCrawledFromIntelligent;
+  } else {
+    ({ dataset } = await createCrawleeSubFolders(randomToken));
+    urlsCrawled = { ...constants.urlsCrawledObj };
 
-     if (fromCrawlIntelligentSitemap) {
-         dataset = datasetFromIntelligent;
-         urlsCrawled = urlsCrawledFromIntelligent;
+    if (!fs.existsSync(randomToken)) {
+      fs.mkdirSync(randomToken);
+    }
+  }
 
-     } else {
-         ({ dataset } = await createCrawleeSubFolders(randomToken));
-         urlsCrawled = { ...constants.urlsCrawledObj };
+  if (fs.existsSync(sitemapUrl)) {
+    linksFromSitemap = [new Request({ url: sitemapUrl })];
+  } else {
+    // File not found
+    throw new Error(`File not found: ${sitemapUrl}`);
+  }
 
-         if (!fs.existsSync(randomToken)) {
-             fs.mkdirSync(randomToken);
-         }
-     }
+  try {
+    sitemapUrl = encodeURI(sitemapUrl);
+  } catch (e) {
+    console.log(e);
+  }
 
-     if (fs.existsSync(sitemapUrl)) {
-         linksFromSitemap = [new Request({ url: sitemapUrl })];
-     } else {
-         // File not found
-         throw new Error(`File not found: ${sitemapUrl}`);
-     }
+  if (basicAuthRegex.test(sitemapUrl)) {
+    isBasicAuth = true;
+    // request to basic auth URL to authenticate for browser session
+    finalLinks.push(new Request({ url: sitemapUrl, uniqueKey: `auth:${sitemapUrl}` }));
+    const finalUrl = `${sitemapUrl.split('://')[0]}://${sitemapUrl.split('@')[1]}`;
+    // obtain base URL without credentials so that subsequent URLs within the same domain can be scanned
+    finalLinks.push(new Request({ url: finalUrl }));
+    basicAuthPage = -2;
+  }
 
-     try {
-         sitemapUrl = encodeURI(sitemapUrl)
-     } catch (e) {
-         console.log(e)
-     }
+  let uuidToPdfMapping: Record<string, string> = {}; //key and value of string type
+  const isScanHtml: boolean = ['all', 'html-only'].includes(fileTypes);
 
-     if (basicAuthRegex.test(sitemapUrl)) {
-         isBasicAuth = true;
-         // request to basic auth URL to authenticate for browser session
-         finalLinks.push(new Request({ url: sitemapUrl, uniqueKey: `auth:${sitemapUrl}` }));
-         const finalUrl = `${sitemapUrl.split('://')[0]}://${sitemapUrl.split('@')[1]}`;
-         // obtain base URL without credentials so that subsequent URLs within the same domain can be scanned
-         finalLinks.push(new Request({ url: finalUrl }));
-         basicAuthPage = -2;
-     }
+  printMessage(['Fetching URLs. This might take some time...'], { border: false });
 
-     let uuidToPdfMapping = {};
-     const isScanHtml = ['all', 'html-only'].includes(fileTypes);
+  finalLinks = [...finalLinks, ...linksFromSitemap];
+  const requestList = new crawlee.RequestList({
+    sources: finalLinks,
+  });
+  await requestList.initialize();
+  printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
 
-     printMessage(['Fetching URLs. This might take some time...'], { border: false });
+  const request = linksFromSitemap[0];
+  const pdfFileName = path.basename(request.url);
+  const trimmedUrl: string = request.url;
+  const destinationFilePath: string = `${randomToken}/${pdfFileName}`;
+  const data: Buffer = fs.readFileSync(trimmedUrl);
+  fs.writeFileSync(destinationFilePath, data);
+  uuidToPdfMapping[pdfFileName] = trimmedUrl;
 
-     finalLinks = [...finalLinks, ...linksFromSitemap];
-     const requestList = new crawlee.RequestList({
-         sources: finalLinks,
-     });
-     await requestList.initialize();
-     printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
+  if (!request.url.endsWith('.pdf')) {
+    let browserUsed;
+    // Playwright only supports chromium,firefox and webkit thus hardcoded to chromium
+    if (browser === 'chromium') {
+      browserUsed = await playwright.chromium.launch();
+    } else if (browser === 'firefox') {
+      browserUsed = await playwright.firefox.launch();
+    } else if (browser === 'webkit') {
+      browserUsed = await playwright.webkit.launch();
+    } else if (browser === 'chrome') {
+      browserUsed = await playwright.chromium.launch(); //chrome not supported, default to chromium
+    } else {
+      console.log('Browser not supported, please use chrome, chromium, firefox, webkit');
+      console.log(' ');
+      return;
+    }
+    const context = await browserUsed.newContext();
+    const page = await context.newPage();
+    request.url = 'file://' + request.url;
+    await page.goto(request.url);
+    const results = await runAxeScript(includeScreenshots, page, randomToken);
+    guiInfoLog(guiInfoStatusTypes.SCANNED, {
+      numScanned: urlsCrawled.scanned.length,
+      urlScanned: request.url,
+    });
 
-     const request = linksFromSitemap[0];
-     const pdfFileName = path.basename(request.url);
-     const trimmedUrl = request.url;
-     const destinationFilePath = `${randomToken}/${pdfFileName}`;
-     const data = fs.readFileSync(trimmedUrl);
-     fs.writeFileSync(destinationFilePath, data);
-     uuidToPdfMapping[pdfFileName] = trimmedUrl;
+    urlsCrawled.scanned.push({
+      url: request.url,
+      pageTitle: results.pageTitle,
+      actualUrl: request.loadedUrl, // i.e. actualUrl
+    });
 
-     if (!request.url.endsWith(".pdf")) {
-         let browserUsed;
-         // Playwright only supports chromium,firefox and webkit thus hardcoded to chromium
-         if (browser === "chromium") {
-             browserUsed = await playwright.chromium.launch();
-         }
-         else if (browser === "firefox") {
-             browserUsed = await playwright.firefox.launch();
-         }
-         else if (browser === "webkit") {
-             browserUsed = await playwright.webkit.launch();
-         }
-         else {
-             console.log("Browser not supported, please use chromium, firefox, webkit")
-             console.log(" ")
-             return;
-         }
-         const context = await browserUsed.newContext();
-         const page = await context.newPage();
-         request.url = "file://" + request.url
-         await page.goto(request.url);
-         const results = await runAxeScript(includeScreenshots, page, randomToken);
-         guiInfoLog(guiInfoStatusTypes.SCANNED, {
-             numScanned: urlsCrawled.scanned.length,
-             urlScanned: request.url,
-         });
+    urlsCrawled.scannedRedirects.push({
+      fromUrl: request.url,
+      toUrl: request.loadedUrl, // i.e. actualUrl
+    });
 
-         urlsCrawled.scanned.push({
-             url: request.url,
-             pageTitle: results.pageTitle,
-             actualUrl: request.loadedUrl, // i.e. actualUrl
-         });
+    results.url = request.url;
+    // results.actualUrl = request.loadedUrl;
 
-         urlsCrawled.scannedRedirects.push({
-             fromUrl: request.url,
-             toUrl: request.loadedUrl, // i.e. actualUrl
-         });
+    await dataset.pushData(results);
+  } else {
+    urlsCrawled.scanned.push({ url: trimmedUrl, pageTitle: pdfFileName });
 
-         results.url = request.url;
-         results.actualUrl = request.loadedUrl;
+    await runPdfScan(randomToken);
+    // transform result format
+    const pdfResults = await mapPdfScanResults(randomToken, uuidToPdfMapping);
 
-         await dataset.pushData(results);
-     }
-     else {
-         urlsCrawled.scanned.push({ url: trimmedUrl, pageTitle: pdfFileName });
-
-         await runPdfScan(randomToken);
-         // transform result format
-         const pdfResults = await mapPdfScanResults(randomToken, uuidToPdfMapping);
-
-         // push results for each pdf document to key value store
-         await Promise.all(pdfResults.map(result => dataset.pushData(result)));
-     }
-     return urlsCrawled;
-
- };
- export default crawlLocalFile; 
+    // push results for each pdf document to key value store
+    await Promise.all(pdfResults.map(result => dataset.pushData(result)));
+  }
+  return urlsCrawled;
+};
+export default crawlLocalFile;

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -1,0 +1,165 @@
+import crawlee, { Request } from 'crawlee';
+ import printMessage from 'print-message';
+ import {
+     createCrawleeSubFolders,
+     preNavigationHooks,
+     runAxeScript,
+     failedRequestHandler,
+     isUrlPdf,
+ } from './commonCrawlerFunc.js';
+
+ import constants, { guiInfoStatusTypes, basicAuthRegex } from '../constants/constants.js';
+ import {
+     getLinksFromSitemap,
+     getPlaywrightLaunchOptions,
+     messageOptions,
+     isSkippedUrl,
+ } from '../constants/common.js';
+ import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
+ import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
+ import fs from 'fs';
+ import { guiInfoLog } from '../logs.js';
+ import playwright from 'playwright';
+ import path from 'path';
+
+ const crawlLocalFile = async (
+     sitemapUrl,
+     randomToken,
+     host,
+     viewportSettings,
+     maxRequestsPerCrawl,
+     browser,
+     userDataDirectory,
+     specifiedMaxConcurrency,
+     fileTypes,
+     blacklistedPatterns,
+     includeScreenshots,
+     extraHTTPHeaders,
+     fromCrawlIntelligentSitemap = false, //optional
+     userUrlInputFromIntelligent = null, //optional
+     datasetFromIntelligent = null, //optional
+     urlsCrawledFromIntelligent = null, //optional
+
+ ) => {
+     let dataset;
+     let urlsCrawled;
+     let linksFromSitemap
+
+     // Boolean to omit axe scan for basic auth URL
+     let isBasicAuth;
+     let basicAuthPage = 0;
+     let finalLinks = [];
+
+     if (fromCrawlIntelligentSitemap) {
+         dataset = datasetFromIntelligent;
+         urlsCrawled = urlsCrawledFromIntelligent;
+
+     } else {
+         ({ dataset } = await createCrawleeSubFolders(randomToken));
+         urlsCrawled = { ...constants.urlsCrawledObj };
+
+         if (!fs.existsSync(randomToken)) {
+             fs.mkdirSync(randomToken);
+         }
+     }
+
+     if (fs.existsSync(sitemapUrl)) {
+         linksFromSitemap = [new Request({ url: sitemapUrl })];
+     } else {
+         // File not found
+         throw new Error(`File not found: ${sitemapUrl}`);
+     }
+
+     try {
+         sitemapUrl = encodeURI(sitemapUrl)
+     } catch (e) {
+         console.log(e)
+     }
+
+     if (basicAuthRegex.test(sitemapUrl)) {
+         isBasicAuth = true;
+         // request to basic auth URL to authenticate for browser session
+         finalLinks.push(new Request({ url: sitemapUrl, uniqueKey: `auth:${sitemapUrl}` }));
+         const finalUrl = `${sitemapUrl.split('://')[0]}://${sitemapUrl.split('@')[1]}`;
+         // obtain base URL without credentials so that subsequent URLs within the same domain can be scanned
+         finalLinks.push(new Request({ url: finalUrl }));
+         basicAuthPage = -2;
+     }
+
+     let uuidToPdfMapping = {};
+     const isScanHtml = ['all', 'html-only'].includes(fileTypes);
+
+     printMessage(['Fetching URLs. This might take some time...'], { border: false });
+
+     finalLinks = [...finalLinks, ...linksFromSitemap];
+     const requestList = new crawlee.RequestList({
+         sources: finalLinks,
+     });
+     await requestList.initialize();
+     printMessage(['Fetch URLs completed. Beginning scan'], messageOptions);
+
+     const request = linksFromSitemap[0];
+     const pdfFileName = path.basename(request.url);
+     const trimmedUrl = request.url;
+     const destinationFilePath = `${randomToken}/${pdfFileName}`;
+     const data = fs.readFileSync(trimmedUrl);
+     fs.writeFileSync(destinationFilePath, data);
+     uuidToPdfMapping[pdfFileName] = trimmedUrl;
+
+     if (!request.url.endsWith(".pdf")) {
+         let browserUsed;
+         // Playwright only supports chromium,firefox and webkit thus hardcoded to chromium
+         if (browser === "chromium") {
+             browserUsed = await playwright.chromium.launch();
+         }
+         else if (browser === "firefox") {
+             browserUsed = await playwright.firefox.launch();
+         }
+         else if (browser === "webkit") {
+             browserUsed = await playwright.webkit.launch();
+         }
+         else {
+             console.log("Browser not supported, please use chromium, firefox, webkit")
+             console.log(" ")
+             return;
+         }
+         const context = await browserUsed.newContext();
+         const page = await context.newPage();
+         request.url = "file://" + request.url
+         await page.goto(request.url);
+         const results = await runAxeScript(includeScreenshots, page, randomToken);
+         guiInfoLog(guiInfoStatusTypes.SCANNED, {
+             numScanned: urlsCrawled.scanned.length,
+             urlScanned: request.url,
+         });
+
+         urlsCrawled.scanned.push({
+             url: request.url,
+             pageTitle: results.pageTitle,
+             actualUrl: request.loadedUrl, // i.e. actualUrl
+         });
+
+         urlsCrawled.scannedRedirects.push({
+             fromUrl: request.url,
+             toUrl: request.loadedUrl, // i.e. actualUrl
+         });
+
+         results.url = request.url;
+         results.actualUrl = request.loadedUrl;
+
+         await dataset.pushData(results);
+     }
+     else {
+         urlsCrawled.scanned.push({ url: trimmedUrl, pageTitle: pdfFileName });
+
+         await runPdfScan(randomToken);
+         // transform result format
+         const pdfResults = await mapPdfScanResults(randomToken, uuidToPdfMapping);
+
+         // push results for each pdf document to key value store
+         await Promise.all(pdfResults.map(result => dataset.pushData(result)));
+     }
+     return urlsCrawled;
+
+ };
+ export default crawlLocalFile; 

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -16,6 +16,7 @@ import {
   isSkippedUrl,
   isFilePath,
   convertLocalFileToPath,
+  convertPathToLocalFile,
 } from '../constants/common.js';
 import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -73,11 +74,11 @@ const crawlLocalFile = async (
   convertLocalFileToPath(sitemapUrl);
 
   // XML Files
-  if (!sitemapUrl.endsWith('.xml')) {
+  if (!sitemapUrl.match(/\.xml$/i)) {
     linksFromSitemap = [new Request({ url: sitemapUrl })];
     
   // Non XML file
-  } else if (sitemapUrl.endsWith('.xml')) {
+  } else {
     const username = '';
     const password = '';
 
@@ -142,7 +143,7 @@ const crawlLocalFile = async (
   fs.writeFileSync(destinationFilePath, data);
   uuidToPdfMapping[pdfFileName] = trimmedUrl;
 
-  if (!request.url.endsWith('.pdf')) {
+  if (!isUrlPdf(request.url)) {
     let browserUsed;
     // Playwright only supports chromium,firefox and webkit thus hardcoded to chromium
     if (browser === 'chromium') {
@@ -160,7 +161,7 @@ const crawlLocalFile = async (
     }
     const context = await browserUsed.newContext();
     const page = await context.newPage();
-    request.url = 'file://' + request.url;
+    request.url = convertPathToLocalFile(request.url);
     await page.goto(request.url);
     const results = await runAxeScript(includeScreenshots, page, randomToken);
     

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -214,7 +214,7 @@ const crawlSitemap = async (
         uuidToPdfMapping[pdfFileName] = trimmedUrl;
         return;
       }
-
+      
       const contentType = response.headers()['content-type'];
       const status = response.status();
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -238,8 +238,8 @@ const crawlSitemap = async (
         basicAuthPage++;
       } else {
         if (true) {
-          console.log("helloo")
           const results = await runAxeScript(includeScreenshots, page, randomToken);
+          // console.log("helloo", results)
           guiInfoLog(guiInfoStatusTypes.SCANNED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
@@ -343,7 +343,7 @@ const crawlSitemap = async (
   if (!fromCrawlIntelligentSitemap) {
     guiInfoLog(guiInfoStatusTypes.COMPLETED);
   }
-
+  console.log("urlsCrawled", urlsCrawled)
   return urlsCrawled;
 };
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -286,14 +286,12 @@ const crawlSitemap = async (
           }
           await dataset.pushData(results);
         } else {
-          // Problem is here
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
           });
   
           isScanHtml && urlsCrawled.invalid.push(actualUrl);
-          return;
           
         }
       }

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -16,6 +16,7 @@ import {
   isSkippedUrl,
   urlWithoutAuth,
   waitForPageLoaded,
+  isFilePath,
 } from '../constants/common.js';
 import { areLinksEqual, isWhitelistedContentType } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -67,12 +68,12 @@ const crawlSitemap = async (
   let username = '';
   let password = '';
 
-  if(!(crawledFromLocalFile) && (sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/'))){
+  if(!(crawledFromLocalFile) && isFilePath(sitemapUrl)){
     console.log("Local file crawling not supported for sitemap. Please provide a valid URL.")
     return;
   }
-  
-  if ((sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/'))) {
+
+  if (isFilePath(sitemapUrl)) {
     parsedUrl = sitemapUrl;
   } else {
     parsedUrl = new URL(sitemapUrl);

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -39,6 +39,7 @@ const crawlSitemap = async (
   userUrlInputFromIntelligent = null, //optional
   datasetFromIntelligent = null, //optional
   urlsCrawledFromIntelligent = null, //optional
+  crawledFromLocalFile
 ) => {
   let dataset;
   let urlsCrawled;
@@ -65,9 +66,14 @@ const crawlSitemap = async (
   let parsedUrl;
   let username = '';
   let password = '';
-  if (sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/')) {
+
+  if(!(crawledFromLocalFile) && (sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/'))){
+    console.log("Local file crawling not supported for sitemap. Please provide a valid URL.")
+    return;
+  }
+  
+  if ((sitemapUrl.startsWith('file:///') || sitemapUrl.startsWith('/'))) {
     parsedUrl = sitemapUrl;
-    console.log(parsedUrl, 'it was here');
   } else {
     parsedUrl = new URL(sitemapUrl);
     if (parsedUrl.username !== '' && parsedUrl.password !== '') {
@@ -340,7 +346,7 @@ const crawlSitemap = async (
   if (!fromCrawlIntelligentSitemap) {
     guiInfoLog(guiInfoStatusTypes.COMPLETED);
   }
-  console.log("urlsCrawled", urlsCrawled)
+
   return urlsCrawled;
 };
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -237,9 +237,8 @@ const crawlSitemap = async (
       if (basicAuthPage < 0) {
         basicAuthPage++;
       } else {
-        if (true) {
+        if (isScanHtml && status === 200 && isWhitelistedContentType(contentType)) {
           const results = await runAxeScript(includeScreenshots, page, randomToken);
-          // console.log("helloo", results)
           guiInfoLog(guiInfoStatusTypes.SCANNED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
@@ -314,9 +313,7 @@ const crawlSitemap = async (
     maxConcurrency: specifiedMaxConcurrency || maxConcurrency,
   });
 
-  console.log(urlsCrawled.invalid, 'urlsCrawled')
   await crawler.run();
-  console.log('hiiiiiii')
   await requestList.isFinished();
 
   if (pdfDownloads.length > 0) {

--- a/src/crawlers/pdfScanFunc.ts
+++ b/src/crawlers/pdfScanFunc.ts
@@ -96,7 +96,6 @@ export const handlePdfDownload = (randomToken, pdfDownloads, request, sendReques
   const pdfFileName = randomUUID();
   const trimmedUrl = request.url.trim();
   const pageTitle = decodeURI(trimmedUrl).split('/').pop();
-  console.log(trimmedUrl)
 
   pdfDownloads.push(
     new Promise(async resolve => {

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -383,14 +383,14 @@ export const generateArtifacts = async (
   pagesNotScanned,
   customFlowLabel,
   cypressScanAboutMetadata,
-  scanDetails
+  scanDetails,
 
 ) => {
   const phAppVersion = getVersion();
   const storagePath = getStoragePath(randomToken);
   const directory = `${storagePath}/${constants.allIssueFileName}`;
-
-  urlScanned = urlWithoutAuth(urlScanned);
+  
+  urlScanned = (scanType === ScannerTypes.SITEMAP || scanType === ScannerTypes.LOCALFILE) ? urlScanned : urlWithoutAuth(urlScanned);
 
   const formatAboutStartTime = dateString => {
     const utcStartTimeDate = new Date(dateString);

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -325,6 +325,7 @@ export const getSelectedPageByLocation = bboxLocation => {
 };
 
 export const getPageFromContext = async (context, pdfFilePath) => {
+  try{
   const loadingTask = pdfjs.getDocument({
     url: pdfFilePath,
     // canvasFactory,
@@ -336,6 +337,9 @@ export const getPageFromContext = async (context, pdfFilePath) => {
   const structureTree = await pdf._pdfInfo.structureTree;
   const page = getBboxPage({ location: context }, structureTree);
   return page;
+} catch (error){
+  // Error handling
+}
 };
 
 export const getBboxPages = (bboxes, structure) => {


### PR DESCRIPTION
- Allow sitemap to be able to recurse all the files (Previously it was just getting the last childSitemap files, instead of all of the files)
- Allow pdfScanFunc to run both filePath and url (it uses fs for file path and got for url)
- Prevent sitemap from recursing infinitely
- Added crawlLocalFile (-c 5)
- Added results and log folder name based on the local file name given
- Added try catch to all the json parsing for sitemap
- Fix bug of able to scan files with dot separator within the file name
- Allow all types of files to be scanned (verapdf for pdf files, axescript for non pdf files)
- Added typing for crawLocalFile.js

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions