### PR TITLE
Feat/add_passed_items

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -101,6 +101,8 @@ const createPassedItemsFile = async (allissues, storagePath) => {
     };
   });
 
+  consoleLogger.info('passed')
+
   try {
     await fs.writeFile(
       `${storagePath}/reports/passed_items.json.txt`,
@@ -113,6 +115,14 @@ const createPassedItemsFile = async (allissues, storagePath) => {
     );
     silentLogger.error(`(writeResults) - ${writeResultsError}`);
   }
+};
+
+const initializeEventListeners = (allIssues, storagePath) => {
+  document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
+    e.preventDefault();
+    await createPassedItemsFile(allIssues, storagePath);
+    consoleLogger.info('click');
+  });
 };
 
 const extractFileNames = async (directory: string): Promise<string[]> =>
@@ -724,9 +734,7 @@ export const generateArtifacts = async (
   await writeSummaryHTML(allIssues, storagePath);
   await writeQueryString(allIssues, storagePath);
   await retryFunction(() => writeSummaryPdf(storagePath), 1);
-  document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
-      e.preventDefault();
-      await createPassedItemsFile(allIssues, storagePath);
-  });
+  await initializeEventListeners(allIssues, storagePath);
   return createRuleIdJson(allIssues);
 };
+

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -83,6 +83,39 @@ type AllIssues = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const createPassedItemsFile = async (allissues, storagePath) => {
+
+  const passedItemsJson = {};
+
+  allissues.items.passed.rules.forEach(r => {
+    passedItemsJson[r.description] = {
+      totalOccurrencesInScan: r.totalItems,
+      totalPages: r.pagesAffected.length,
+      pages: r.pagesAffected.map(p => ({
+        pageTitle: p.pageTitle,
+        url: p.url,
+        totalOccurrencesInPage: p.items.length,
+        occurrences: p.items,
+        metadata: p.metadata 
+      })),
+    };
+  });
+
+  try {
+    await fs.writeFile(
+      `${storagePath}/reports/passed_items.json.txt`,
+      JSON.stringify(passedItemsJson, null, 4),
+    );
+    consoleLogger.info('Passed items file has been created successfully.');
+  } catch (writeResultsError) {
+    consoleLogger.info(
+      'An error has occurred when compiling the results into the report, please try again.',
+    );
+    silentLogger.error(`(writeResults) - ${writeResultsError}`);
+  }
+};
+
+
 const extractFileNames = async (directory: string): Promise<string[]> =>
   fs
     .readdir(directory)

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -225,7 +225,6 @@ const base64Encode = data => {
 
 const writeBase64 = async (allIssues, storagePath, htmlFilename = 'report.html') => {
 
-  console.log(allIssues.items.passed)
   const { items, ...rest } = allIssues;
 
   const encodedScanItems = base64Encode(items);
@@ -650,7 +649,6 @@ export const generateArtifacts = async (
       },
       passed: {
         occurrence: allIssues.items.passed.totalItems,
-        rules: allIssues.items.passed.rules,
       },
     };
 
@@ -687,8 +685,8 @@ export const generateArtifacts = async (
 
   await writeCsv(allIssues, storagePath);
   await writeHTML(allIssues, storagePath);
-  await writeSummaryHTML(allIssues, storagePath);
   await writeBase64(allIssues, storagePath);
+  await writeSummaryHTML(allIssues, storagePath);
   await retryFunction(() => writeSummaryPdf(storagePath), 1);
   return createRuleIdJson(allIssues);
 };

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -360,7 +360,6 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
           // numberOfPagesAffectedAfterRedirects: 0,
           pagesAffected: {},
         };
-        console.log(category)
       }
 
       if (category !== 'passed' && category !== 'needsReview') {

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -83,39 +83,37 @@ type AllIssues = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// const createPassedItemsFile = async (allissues, storagePath) => {
+const createPassedItemsFile = async (allissues, storagePath) => {
 
-//   const passedItemsJson = {};
+  const passedItemsJson = {};
 
-//   allissues.items.passed.rules.forEach(r => {
-//     passedItemsJson[r.description] = {
-//       totalOccurrencesInScan: r.totalItems,
-//       totalPages: r.pagesAffected.length,
-//       pages: r.pagesAffected.map(p => ({
-//         pageTitle: p.pageTitle,
-//         url: p.url,
-//         totalOccurrencesInPage: p.items.length,
-//         occurrences: p.items,
-//         metadata: p.metadata 
-//       })),
-//     };
-//   });
+  allissues.items.passed.rules.forEach(r => {
+    passedItemsJson[r.description] = {
+      totalOccurrencesInScan: r.totalItems,
+      totalPages: r.pagesAffected.length,
+      pages: r.pagesAffected.map(p => ({
+        pageTitle: p.pageTitle,
+        url: p.url,
+        totalOccurrencesInPage: p.items.length,
+        occurrences: p.items,
+        metadata: p.metadata 
+      })),
+    };
+  });
 
-//   try {
-//     await fs.writeFile(
-//       `${storagePath}/reports/passed_items.json.txt`,
-//       JSON.stringify(passedItemsJson, null, 4),
-//     );
-//     consoleLogger.info('Passed items file has been created successfully.');
-//   } catch (writeResultsError) {
-//     consoleLogger.info(
-//       'An error has occurred when compiling the results into the report, please try again.',
-//     );
-//     silentLogger.error(`(writeResults) - ${writeResultsError}`);
-//   }
-// };
-
-// module.exports = { createPassedItemsFile };
+  try {
+    await fs.writeFile(
+      `${storagePath}/reports/passed_items.json.txt`,
+      JSON.stringify(passedItemsJson, null, 4),
+    );
+    consoleLogger.info('Passed items file has been created successfully.');
+  } catch (writeResultsError) {
+    consoleLogger.info(
+      'An error has occurred when compiling the results into the report, please try again.',
+    );
+    silentLogger.error(`(writeResults) - ${writeResultsError}`);
+  }
+};
 
 const extractFileNames = async (directory: string): Promise<string[]> =>
   fs
@@ -726,5 +724,9 @@ export const generateArtifacts = async (
   await writeSummaryHTML(allIssues, storagePath);
   await writeQueryString(allIssues, storagePath);
   await retryFunction(() => writeSummaryPdf(storagePath), 1);
+  document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
+      e.preventDefault();
+      await createPassedItemsFile(allIssues, storagePath);
+  });
   return createRuleIdJson(allIssues);
 };

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -36,6 +36,7 @@ type PageInfo = {
   url?: string;
   pageImagePath?: string;
   pageIndex?: number;
+  metadata: string;
 };
 
 type RuleInfo = {
@@ -82,6 +83,7 @@ type AllIssues = {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+let allIssues;
 
 const extractFileNames = async (directory: string): Promise<string[]> =>
   fs
@@ -222,30 +224,27 @@ const base64Encode = data => {
 };
 
 const writeBase64 = async (allIssues, storagePath, htmlFilename = 'report.html') => {
-  // Spread the data
+
+  console.log(allIssues.items.passed)
   const { items, ...rest } = allIssues;
 
-  // Encode the data
   const encodedScanItems = base64Encode(items);
   const encodedScanData = base64Encode(rest);
 
-  // Path to the file where the encoded data will be saved
-  const filePath = path.join(storagePath, 'reports', 'reportScanData.csv');
+  const filePath = path.join(storagePath, 'reports', 'scanDetails.csv');
 
-  // Ensure directory existence
   const directoryPath = path.dirname(filePath);
   if (!fs.existsSync(directoryPath)) {
     fs.mkdirSync(directoryPath, { recursive: true });
   }
 
-  // Write the encoded scan data to the file
   await fs.promises.writeFile(filePath, `scanData_base64,scanItems_base64\n${encodedScanData},${encodedScanItems}`);
 
-  // Read the existing HTML file
   const htmlFilePath = path.join(storagePath, 'reports', htmlFilename);
   let htmlContent = fs.readFileSync(htmlFilePath, 'utf8');
 
-  // Find the position to insert the script tag in the head section
+  const allIssuesJson = JSON.stringify(allIssues);
+
   const headIndex = htmlContent.indexOf('</head>');
   const injectScript = `
   <script>
@@ -260,18 +259,16 @@ const writeBase64 = async (allIssues, storagePath, htmlFilename = 'report.html')
     // Decode the encoded data
     scanData = base64Decode('${encodedScanData}');
     scanItems = base64Decode('${encodedScanItems}');
+    allIssues = ${allIssuesJson};
   </script>
   `;
 
   if (headIndex !== -1) {
-    // If </head> tag is found, insert the script tag before it
     htmlContent = htmlContent.slice(0, headIndex) + injectScript + htmlContent.slice(headIndex);
   } else {
-    // If </head> tag is not found, append the script tag at the end of the file
     htmlContent += injectScript;
   }
 
-  // Write the updated HTML content back to the file
   fs.writeFileSync(htmlFilePath, htmlContent);
 };
 
@@ -364,6 +361,7 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
           // numberOfPagesAffectedAfterRedirects: 0,
           pagesAffected: {},
         };
+        console.log(category)
       }
 
       if (category !== 'passed' && category !== 'needsReview') {
@@ -652,6 +650,7 @@ export const generateArtifacts = async (
       },
       passed: {
         occurrence: allIssues.items.passed.totalItems,
+        rules: allIssues.items.passed.rules,
       },
     };
 

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -83,38 +83,39 @@ type AllIssues = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const createPassedItemsFile = async (allissues, storagePath) => {
+// const createPassedItemsFile = async (allissues, storagePath) => {
 
-  const passedItemsJson = {};
+//   const passedItemsJson = {};
 
-  allissues.items.passed.rules.forEach(r => {
-    passedItemsJson[r.description] = {
-      totalOccurrencesInScan: r.totalItems,
-      totalPages: r.pagesAffected.length,
-      pages: r.pagesAffected.map(p => ({
-        pageTitle: p.pageTitle,
-        url: p.url,
-        totalOccurrencesInPage: p.items.length,
-        occurrences: p.items,
-        metadata: p.metadata 
-      })),
-    };
-  });
+//   allissues.items.passed.rules.forEach(r => {
+//     passedItemsJson[r.description] = {
+//       totalOccurrencesInScan: r.totalItems,
+//       totalPages: r.pagesAffected.length,
+//       pages: r.pagesAffected.map(p => ({
+//         pageTitle: p.pageTitle,
+//         url: p.url,
+//         totalOccurrencesInPage: p.items.length,
+//         occurrences: p.items,
+//         metadata: p.metadata 
+//       })),
+//     };
+//   });
 
-  try {
-    await fs.writeFile(
-      `${storagePath}/reports/passed_items.json.txt`,
-      JSON.stringify(passedItemsJson, null, 4),
-    );
-    consoleLogger.info('Passed items file has been created successfully.');
-  } catch (writeResultsError) {
-    consoleLogger.info(
-      'An error has occurred when compiling the results into the report, please try again.',
-    );
-    silentLogger.error(`(writeResults) - ${writeResultsError}`);
-  }
-};
+//   try {
+//     await fs.writeFile(
+//       `${storagePath}/reports/passed_items.json.txt`,
+//       JSON.stringify(passedItemsJson, null, 4),
+//     );
+//     consoleLogger.info('Passed items file has been created successfully.');
+//   } catch (writeResultsError) {
+//     consoleLogger.info(
+//       'An error has occurred when compiling the results into the report, please try again.',
+//     );
+//     silentLogger.error(`(writeResults) - ${writeResultsError}`);
+//   }
+// };
 
+// module.exports = { createPassedItemsFile };
 
 const extractFileNames = async (directory: string): Promise<string[]> =>
   fs

--- a/src/static/ejs/partials/components/scanAbout.ejs
+++ b/src/static/ejs/partials/components/scanAbout.ejs
@@ -138,10 +138,10 @@
         </defs>
       </svg>
       <button
-        id="pagesScannedModalToggletxt"
+        id="pagesScannedModalToggle"
         data-bs-toggle="modal"
         data-bs-target="#pagesScannedModal"
-        >NA
+        ><span id="pagesScannedModalToggletxt">NA</span>
       <% if (totalPagesNotScanned > 0) { %>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
           <path d="M12 19.875C9.91142 19.875 7.90838 19.0453 6.43153 17.5685C4.95468 16.0916 4.125 14.0886 4.125 12C4.125 9.91142 4.95468 7.90838 6.43153 6.43153C7.90838 4.95468 9.91142 4.125 12 4.125C14.0886 4.125 16.0916 4.95468 17.5685 6.43153C19.0453 7.90838 19.875 9.91142 19.875 12C19.875 14.0886 19.0453 16.0916 17.5685 17.5685C16.0916 19.0453 14.0886 19.875 12 19.875ZM12 21C14.3869 21 16.6761 20.0518 18.364 18.364C20.0518 16.6761 21 14.3869 21 12C21 9.61305 20.0518 7.32387 18.364 5.63604C16.6761 3.94821 14.3869 3 12 3C9.61305 3 7.32387 3.94821 5.63604 5.63604C3.94821 7.32387 3 9.61305 3 12C3 14.3869 3.94821 16.6761 5.63604 18.364C7.32387 20.0518 9.61305 21 12 21Z" fill="#D7260F"/>
@@ -196,8 +196,8 @@
           </clipPath>
         </defs>
       </svg>
-      <span id="items">
-        NA
+      <span>
+        <span id="items">NA</span>
         <svg
           tabindex="-1"
           id="passedItemsTooltip"

--- a/src/static/ejs/partials/components/scanAbout.ejs
+++ b/src/static/ejs/partials/components/scanAbout.ejs
@@ -138,7 +138,7 @@
         </defs>
       </svg>
       <button
-        id="pagesScannedModalToggle"
+        id="pagesScannedModalToggletxt"
         data-bs-toggle="modal"
         data-bs-target="#pagesScannedModal"
         >NA

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -196,13 +196,6 @@
         }
 
         document.getElementById('pagesScannedModalLabel').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
-
-        // const { createPassedItemsFile } = require('./createPassedItemsFile');
-        // document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
-        //     e.preventDefault();
-        //     await createPassedItemsFile(allissues, storagePath);
-        // });
-
       };
 
       const formatAboutStartTime = dateString => {

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -122,9 +122,10 @@
         var itemsElement = document.getElementById('items');
         var failedItems = scanItems.mustFix.totalItems + scanItems.goodToFix.totalItems;
         var passedItems = scanItems.passed.totalItems;
-        var itemsContent = `${failedItems} ${failedItems === 1 ? 'occurrence' : 'occurrences'} failed,<br>${passedItems} ${passedItems === 1 ? 'occurrence' : 'occurrences'} passed`;
+        var itemsContent = `${failedItems} ${failedItems === 1 ? 'occurrence' : 'occurrences'} failed,<br>
+        <a href="#" id="createPassedItemsFile">${passedItems} ${passedItems === 1 ? 'occurrence' : 'occurrences'} passed</a>`;
         itemsElement.innerHTML = itemsContent;
- 
+
         var phAppVersionElement = document.getElementById('phAppVersion');
         var versionContent = 'Purple A11y Version ' + scanData.phAppVersion;
         phAppVersionElement.innerHTML = versionContent;
@@ -196,6 +197,10 @@
 
         document.getElementById('pagesScannedModalLabel').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
 
+        document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
+            e.preventDefault();
+            await createPassedItemsFile(allissues, storagePath);
+        });
 
       };
 

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -214,20 +214,23 @@
             };
           });
 
-          const fs = require('fs');
-
           const jsonString = JSON.stringify(passedItemsJson, null, 4);
 
-          const storagePath = scanData.storagePath;
-          const filePath = `${storagePath}/reports/passed_items.json.txt`;
+          const blob = new Blob([jsonString], { type: "application/json" });
 
-          fs.writeFile(filePath, jsonString, (err) => {
-              if (err) {
-                  console.error('Error writing file:', err);
-                  return;
-              }
-              console.log('File saved successfully.');
-          });
+          const link = document.createElement("a");
+
+          link.href = URL.createObjectURL(blob);
+
+          storagePath = scanData.storagePath;
+
+          link.download = `passed_items.json.txt`;
+
+          document.body.appendChild(link);
+
+          link.click();
+
+          document.body.removeChild(link);
 
         };
 

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -219,12 +219,19 @@
           const blob = new Blob([jsonString], { type: "application/json" });
 
           const link = document.createElement("a");
+
           link.href = URL.createObjectURL(blob);
-          link.download = "passed_items.json.txt";
+
+          storagePath = scanData.storagePath;
+          
+          link.download = `${storagePath}/reports/passed_items.json.txt`;
+
           document.body.appendChild(link);
 
           link.click();
+
           document.body.removeChild(link);
+
         };
 
         document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -197,50 +197,41 @@
 
         document.getElementById('pagesScannedModalLabel').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
 
-const createPassedItemsFile = async () => {
-  const passedItemsJson = {};
+        const createPassedItemsFile = async () => {
+          const passedItemsJson = {};
 
-  // Assuming scanItems and scanData are accessible here
-  scanItems.passed.rules.forEach(r => {
-    passedItemsJson[r.description] = {
-      totalOccurrencesInScan: r.totalItems,
-      totalPages: r.pagesAffected.length,
-      pages: r.pagesAffected.map(p => ({
-        pageTitle: p.pageTitle,
-        url: p.url,
-        totalOccurrencesInPage: p.items.length,
-        occurrences: p.items,
-        metadata: p.metadata 
-      })),
-    };
-  });
+          scanItems.passed.rules.forEach(r => {
+            passedItemsJson[r.description] = {
+              totalOccurrencesInScan: r.totalItems,
+              totalPages: r.pagesAffected.length,
+              pages: r.pagesAffected.map(p => ({
+                pageTitle: p.pageTitle,
+                url: p.url,
+                totalOccurrencesInPage: p.items.length,
+                occurrences: p.items,
+                metadata: p.metadata 
+              })),
+            };
+          });
 
-  console.log('passed');
+          const jsonString = JSON.stringify(passedItemsJson, null, 4);
 
-  // Convert JSON to string
-  const jsonString = JSON.stringify(passedItemsJson, null, 4);
+          const blob = new Blob([jsonString], { type: "application/json" });
 
-// Create a blob containing the JSON data
-const blob = new Blob([jsonString], { type: "application/json" });
+          const link = document.createElement("a");
+          link.href = URL.createObjectURL(blob);
+          link.download = "passed_items.json.txt";
+          document.body.appendChild(link);
 
-// Create a link element to trigger the download
-const link = document.createElement("a");
-link.href = URL.createObjectURL(blob);
-link.download = "passed_items.json.txt";
-document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        };
 
-// Trigger the download
-link.click();
-
-// Cleanup
-document.body.removeChild(link);
-};
-
-document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
-  e.preventDefault();
-  await createPassedItemsFile();
-  console.log('click');
-});
+        document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
+          e.preventDefault();
+          await createPassedItemsFile();
+          console.log('click');
+        });
 
       };
 

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -214,23 +214,20 @@
             };
           });
 
+          const fs = require('fs');
+
           const jsonString = JSON.stringify(passedItemsJson, null, 4);
 
-          const blob = new Blob([jsonString], { type: "application/json" });
+          const storagePath = scanData.storagePath;
+          const filePath = `${storagePath}/reports/passed_items.json.txt`;
 
-          const link = document.createElement("a");
-
-          link.href = URL.createObjectURL(blob);
-
-          storagePath = scanData.storagePath;
-          
-          link.download = `${storagePath}/reports/passed_items.json.txt`;
-
-          document.body.appendChild(link);
-
-          link.click();
-
-          document.body.removeChild(link);
+          fs.writeFile(filePath, jsonString, (err) => {
+              if (err) {
+                  console.error('Error writing file:', err);
+                  return;
+              }
+              console.log('File saved successfully.');
+          });
 
         };
 

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -196,6 +196,52 @@
         }
 
         document.getElementById('pagesScannedModalLabel').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
+
+const createPassedItemsFile = async () => {
+  const passedItemsJson = {};
+
+  // Assuming scanItems and scanData are accessible here
+  scanItems.passed.rules.forEach(r => {
+    passedItemsJson[r.description] = {
+      totalOccurrencesInScan: r.totalItems,
+      totalPages: r.pagesAffected.length,
+      pages: r.pagesAffected.map(p => ({
+        pageTitle: p.pageTitle,
+        url: p.url,
+        totalOccurrencesInPage: p.items.length,
+        occurrences: p.items,
+        metadata: p.metadata 
+      })),
+    };
+  });
+
+  console.log('passed');
+
+  // Convert JSON to string
+  const jsonString = JSON.stringify(passedItemsJson, null, 4);
+
+// Create a blob containing the JSON data
+const blob = new Blob([jsonString], { type: "application/json" });
+
+// Create a link element to trigger the download
+const link = document.createElement("a");
+link.href = URL.createObjectURL(blob);
+link.download = "passed_items.json.txt";
+document.body.appendChild(link);
+
+// Trigger the download
+link.click();
+
+// Cleanup
+document.body.removeChild(link);
+};
+
+document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
+  e.preventDefault();
+  await createPassedItemsFile();
+  console.log('click');
+});
+
       };
 
       const formatAboutStartTime = dateString => {

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -117,7 +117,7 @@
         document.getElementById('urlScanned').innerHTML = scanData.urlScanned;
         document.getElementById('urlScanned').href = scanData.urlScanned;
         document.getElementById('viewport').innerHTML = scanData.viewport.startsWith("CustomWidth") ? `${scanData.viewport.split("_")[1]} width viewport` : scanData.viewport + ' viewport';
-        document.getElementById('pagesScannedModalToggle').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
+        document.getElementById('pagesScannedModalToggletxt').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
 
         var itemsElement = document.getElementById('items');
         var failedItems = scanItems.mustFix.totalItems + scanItems.goodToFix.totalItems;
@@ -197,10 +197,11 @@
 
         document.getElementById('pagesScannedModalLabel').innerHTML = scanData.isCustomFlow ? scanData.customFlowLabel + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')' : scanData.scanType + ' crawl' + ' (' + scanData.totalPagesScanned + ' ' + (scanData.totalPagesScanned === 1 ? 'page' : 'pages') + ')';
 
-        document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
-            e.preventDefault();
-            await createPassedItemsFile(allissues, storagePath);
-        });
+        // const { createPassedItemsFile } = require('./createPassedItemsFile');
+        // document.getElementById('createPassedItemsFile').addEventListener('click', async (e) => {
+        //     e.preventDefault();
+        //     await createPassedItemsFile(allissues, storagePath);
+        // });
 
       };
 


### PR DESCRIPTION
This PR adds svgs for occurrences and crawl and add download passed items txt when click on passed occurrence.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
