### PR TITLE
chore: add typescript examples for the integration guide

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -439,7 +439,7 @@ interface Window {
 }
 ```
 
-Run your test with <code>npx tsc</code> .
+Compile your typescript code with <code>npx tsc</code> .
 Run your test with <code>npx cypress run</code> .
 
 You will see Purple A11y results generated in <code>results</code> folder.
@@ -449,11 +449,11 @@ You will see Purple A11y results generated in <code>results</code> folder.
 #### Playwright
 
 <details>
-    <summary>Click here to see an example usage in Playwright</summary>
+    <summary>Click here to see an example usage in Playwright (javascript)</summary>
 
 Create a <code>package.json</code> by running <code>npm init</code> . Accept the default options or customise it as needed.
 
-Change the type of npm package to module by running <code>npm pkg set type="module"</code>;
+Change the type of npm package to module by running <code>npm pkg set type="module"</code>
 
 Install the following node dependencies by running <code>npm install playwright @govtechsg/purple-hats --save-dev</code> and <code>npx playwright install</code>
 
@@ -519,6 +519,97 @@ On your project's root folder, create a Playwright test file <code>purpleA11y-pl
     })();
 
 Run your test with <code>node purpleA11y-playwright-demo.js</code> .
+
+You will see Purple A11y results generated in <code>results</code> folder.
+
+</details>
+<details>
+    <summary>Click here to see an example usage in Playwright (typescript)</summary>
+
+Create a <code>package.json</code> by running <code>npm init</code> . Accept the default options or customise it as needed.
+
+Change the type of npm package to module by running <code>npm pkg set type="module"</code>
+
+Install the following node dependencies by running <code>npm install playwright @govtechsg/purple-hats typescript --save-dev</code> and <code>npx playwright install</code>
+
+Create a <code>tsconfig.json</code> in the root directory and add the following:
+```
+    {
+    "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "es2021",
+    "module": "nodenext",
+    "rootDir": "./src",
+    "skipLibCheck": true
+    },
+    "include": ["./src/**/*"]
+    }
+```
+
+Navigate to <code>node_modules/@govtechsg/purple-hats</code> and run <code>npm install</code> and <code>npm run build</code> within the folder to install remaining Purple A11y dependencies:
+
+    cd node_modules/@govtechsg/purple-hats
+    npm install
+    npm run build
+    cd ../../..
+
+Create a sub-folder and Playwright test file <code>src/purpleA11y-playwright-demo.ts</code> with the following contents:
+
+    import { chromium } from "playwright";
+    import purpleA11yInit from "@govtechsg/purple-hats";
+
+    // viewport used in tests to optimise screenshots
+    const viewportSettings = { width: 1920, height: 1040 };
+    // specifies the number of occurrences before error is thrown for test failure
+    const thresholds = { mustFix: 20, goodToFix: 25 };
+    // additional information to include in the "Scan About" section of the report
+    const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
+
+    const purpleA11y = await purpleA11yInit(
+        "https://govtechsg.github.io", // initial url to start scan
+        "Demo Playwright Scan", // label for test
+        "Your Name",
+        "email@domain.com",
+        true, // include screenshots of affected elements in the report
+        viewportSettings,
+        thresholds,
+        scanAboutMetadata,
+    );
+
+    (async () => {
+        const browser = await chromium.launch({
+            headless: false,
+        });
+        const context = await browser.newContext();
+        const page = await context.newPage();
+
+        const runPurpleA11yScan = async (elementsToScan) => {
+            const scanRes = await page.evaluate(
+                async elementsToScan => await runA11yScan(elementsToScan),
+                elementsToScan,
+            );
+            await purpleA11y.pushScanResults(scanRes);
+            purpleA11y.testThresholds(); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
+        };
+
+        await page.goto('https://govtechsg.github.io/purple-banner-embeds/purple-integrated-scan-example.htm');
+        await page.evaluate(purpleA11y.getScripts());
+        await runPurpleA11yScan();
+
+        await page.getByRole('button', { name: 'Click Me' }).click();
+        // Run a scan on <input> and <button> elements
+        await runPurpleA11yScan(['input', 'button'])
+
+
+        // ---------------------
+        await context.close();
+        await browser.close();
+        await purpleA11y.terminate();
+    })();
+
+Compile your typescript code with <code>npx tsc</code> .
+Run your test with <code>node dist/purpleA11y-playwright-demo.js</code> .
 
 You will see Purple A11y results generated in <code>results</code> folder.
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -168,7 +168,7 @@ Create <code>cypress.config.js</code> with the following contents, and change yo
     // viewport used in tests to optimise screenshots
     const viewportSettings = { width: 1920, height: 1040 };
     // specifies the number of occurrences before error is thrown for test failure
-    const thresholds = { mustFix: 4, goodToFix: 5 };
+    const thresholds = { mustFix: 20, goodToFix: 25 };
     // additional information to include in the "Scan About" section of the report
     const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
 
@@ -292,7 +292,7 @@ Create a <code>tsconfig.json</code> in the root directory and add the following:
     "skipLibCheck": true,
     "types": ["cypress"]
     },
-    "include": ["./src/**/*"]
+    "include": ["./src/**/*", "cypress.d.ts"]
     }
 ```
 
@@ -311,7 +311,7 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
     // viewport used in tests to optimise screenshots
     const viewportSettings = { width: 1920, height: 1040 };
     // specifies the number of occurrences before error is thrown for test failure
-    const thresholds = { mustFix: 4, goodToFix: 5 };
+    const thresholds = { mustFix: 20, goodToFix: 25 };
     // additional information to include in the "Scan About" section of the report
     const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
 
@@ -401,6 +401,27 @@ Create <code>src/cypress/e2e/spec.cy.ts</code> with the following contents:
         });
     });
 
+Create <code>cypress.d.ts</code> in the root directory with the following contents:
+```
+declare namespace Cypress {
+  interface Chainable<Subject> {
+    injectPurpleA11yScripts(): Chainable<void>;
+    runPurpleA11yScan(options?: PurpleA11yScanOptions): Chainable<void>;
+    terminatePurpleA11y(): Chainable<void>;
+  }
+
+  interface PurpleA11yScanOptions {
+    elementsToScan?: string[];
+    elementsToClick?: string[];
+    metadata?: string;
+  }
+}
+
+interface Window {
+  runA11yScan: (elementsToScan?: string[]) => Promise<any>;
+}
+```
+
 Run your test with <code>npx tsc</code> .
 Run your test with <code>npx cypress run</code> .
 
@@ -434,7 +455,7 @@ On your project's root folder, create a Playwright test file <code>purpleA11y-pl
     // viewport used in tests to optimise screenshots
     const viewportSettings = { width: 1920, height: 1040 };
     // specifies the number of occurrences before error is thrown for test failure
-    const thresholds = { mustFix: 4, goodToFix: 5 };
+    const thresholds = { mustFix: 20, goodToFix: 25 };
     // additional information to include in the "Scan About" section of the report
     const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -259,8 +259,7 @@ Create <code>cypress/e2e/spec.cy.js</code> with the following contents:
         });
     });
 
-Run your test with <code>npx cypress run</code> .
-
+Run your test with <code>npx cypress run</code>.  
 You will see Purple A11y results generated in <code>results</code> folder.
 
 </details>
@@ -285,18 +284,18 @@ Install the following node dependencies by running <code>npm install cypress @ty
 
 Create a <code>tsconfig.json</code> in the root directory and add the following:
 ```
-    {
-    "compilerOptions": {
-    "outDir": "./dist",
-    "allowJs": true,
-    "target": "es2021",
-    "module": "nodenext",
-    "rootDir": "./src",
-    "skipLibCheck": true,
-    "types": ["cypress"]
-    },
-    "include": ["./src/**/*", "cypress.d.ts"]
-    }
+{
+"compilerOptions": {
+"outDir": "./dist",
+"allowJs": true,
+"target": "es2021",
+"module": "nodenext",
+"rootDir": "./src",
+"skipLibCheck": true,
+"types": ["cypress"]
+},
+"include": ["./src/**/*", "cypress.d.ts"]
+}
 ```
 
 Navigate to <code>node_modules/@govtechsg/purple-hats</code> and run <code>npm install</code> and <code>npm run build</code> within the folder to install remaining Purple A11y dependencies:
@@ -439,8 +438,8 @@ interface Window {
 }
 ```
 
-Compile your typescript code with <code>npx tsc</code> .
-Run your test with <code>npx cypress run</code> .
+Compile your typescript code with <code>npx tsc</code>.  
+Run your test with <code>npx cypress run</code>.
 
 You will see Purple A11y results generated in <code>results</code> folder.
 
@@ -534,17 +533,17 @@ Install the following node dependencies by running <code>npm install playwright 
 
 Create a <code>tsconfig.json</code> in the root directory and add the following:
 ```
-    {
-    "compilerOptions": {
-    "outDir": "./dist",
-    "allowJs": true,
-    "target": "es2021",
-    "module": "nodenext",
-    "rootDir": "./src",
-    "skipLibCheck": true
-    },
-    "include": ["./src/**/*"]
-    }
+{
+"compilerOptions": {
+"outDir": "./dist",
+"allowJs": true,
+"target": "es2021",
+"module": "nodenext",
+"rootDir": "./src",
+"skipLibCheck": true
+},
+"include": ["./src/**/*"]
+}
 ```
 
 Navigate to <code>node_modules/@govtechsg/purple-hats</code> and run <code>npm install</code> and <code>npm run build</code> within the folder to install remaining Purple A11y dependencies:
@@ -556,15 +555,31 @@ Navigate to <code>node_modules/@govtechsg/purple-hats</code> and run <code>npm i
 
 Create a sub-folder and Playwright test file <code>src/purpleA11y-playwright-demo.ts</code> with the following contents:
 
-    import { chromium } from "playwright";
+    import { Browser, BrowserContext, Page, chromium } from "playwright";
     import purpleA11yInit from "@govtechsg/purple-hats";
 
+    declare const runA11yScan: (elementsToScan?: string[]) => Promise<any>;
+
+    interface ViewportSettings {
+        width: number;
+        height: number;
+    }
+
+    interface Thresholds {
+        mustFix: number;
+        goodToFix: number;
+    }
+
+    interface ScanAboutMetadata {
+        browser: string;
+    }
+
     // viewport used in tests to optimise screenshots
-    const viewportSettings = { width: 1920, height: 1040 };
+    const viewportSettings: ViewportSettings = { width: 1920, height: 1040 };
     // specifies the number of occurrences before error is thrown for test failure
-    const thresholds = { mustFix: 20, goodToFix: 25 };
+    const thresholds: Thresholds = { mustFix: 20, goodToFix: 25 };
     // additional information to include in the "Scan About" section of the report
-    const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
+    const scanAboutMetadata: ScanAboutMetadata = { browser: 'Chrome (Desktop)' };
 
     const purpleA11y = await purpleA11yInit(
         "https://govtechsg.github.io", // initial url to start scan
@@ -578,13 +593,13 @@ Create a sub-folder and Playwright test file <code>src/purpleA11y-playwright-dem
     );
 
     (async () => {
-        const browser = await chromium.launch({
+        const browser: Browser = await chromium.launch({
             headless: false,
         });
-        const context = await browser.newContext();
-        const page = await context.newPage();
+        const context: BrowserContext = await browser.newContext();
+        const page: Page = await context.newPage();
 
-        const runPurpleA11yScan = async (elementsToScan) => {
+        const runPurpleA11yScan = async (elementsToScan?: string[]) => {
             const scanRes = await page.evaluate(
                 async elementsToScan => await runA11yScan(elementsToScan),
                 elementsToScan,
@@ -608,8 +623,8 @@ Create a sub-folder and Playwright test file <code>src/purpleA11y-playwright-dem
         await purpleA11y.terminate();
     })();
 
-Compile your typescript code with <code>npx tsc</code> .
-Run your test with <code>node dist/purpleA11y-playwright-demo.js</code> .
+Compile your typescript code with <code>npx tsc</code>.  
+Run your test with <code>node dist/purpleA11y-playwright-demo.js</code>.
 
 You will see Purple A11y results generated in <code>results</code> folder.
 
@@ -618,7 +633,7 @@ You will see Purple A11y results generated in <code>results</code> folder.
 #### Automating Web Crawler Login
 
 <details>
-    <summary>Click here to see an example automated web crawler login</summary>
+    <summary>Click here to see an example automated web crawler login (javascript)</summary>
 <code>automated-web-crawler-login.js</code>:
    
     import { chromium } from 'playwright';
@@ -644,12 +659,12 @@ You will see Purple A11y results generated in <code>results</code> folder.
 
         // Retrieve cookies after login
         let cookies = await page.context().cookies();
-        cookies = formatCookies(cookies);
+        const formattedCookies = formatCookies(cookies);
 
         // Close browser
         await browser.close();
 
-        return cookies;
+        return formattedCookies;
     };
 
     const runPurpleA11yScan = command => {
@@ -686,5 +701,76 @@ You will see Purple A11y results generated in <code>results</code> folder.
     };
 
     runScript();
+
+</details>
+<details>
+    <summary>Click here to see an example automated web crawler login (typescript)</summary>
+<code>automated-web-crawler-login.ts</code>:
+   
+    import { chromium, Browser, Page, Cookie } from 'playwright';
+    import { exec } from 'child_process';
+
+    const loginAndCaptureHeaders = async (url: string, email: string, password: string): Promise<string> => {
+        const browser: Browser = await chromium.launch({ headless: true });
+        const page: Page = await browser.newPage();
+
+        await page.goto(url);
+        await page.fill('input[name="email"]', email);
+        await page.fill('input[name="password"]', password);
+
+        const [response] = await Promise.all([
+            page.waitForNavigation(),
+            page.click('input[type="submit"]'),
+        ]);
+
+        // Format cookie retrieved from page
+        const formatCookies = (cookies: Cookie[]): string => {
+            return cookies.map(cookie => `cookie ${cookie.name}=${cookie.value}`).join('; ');
+        };
+
+        // Retrieve cookies after login
+        let cookies: Cookie[] = await page.context().cookies();
+        const formattedCookies: string = formatCookies(cookies);
+
+        // Close browser
+        await browser.close();
+
+        return formattedCookies;
+    };
+
+    const runPurpleA11yScan = (command: string): void => {
+        exec(command, (error, stdout, stderr) => {
+            if (error) {
+                console.error(`Error: ${error.message}`);
+                return;
+            }
+            if (stderr) {
+                console.error(stderr);
+            }
+            console.log(stdout);
+        });
+    };
+
+    const runScript = (): void => {
+        loginAndCaptureHeaders(
+            // Test example with authenticationtest.com
+            'https://authenticationtest.com/simpleFormAuth/',
+            'simpleForm@authenticationtest.com',
+            'pa$$w0rd',
+        )
+            .then((formattedCookies: string) => {
+                console.log('Cookies retrieved.\n');
+                // where -m "..." are the headers needed in the format "header1 value1, header2 value2" etc
+                // where -u ".../loginSuccess/" is the destination page after login
+                const command: string = `npm run cli -- -c website -u "https://authenticationtest.com/loginSuccess/" -p 1 -k "Your Name:email@domain.com" -m "${formattedCookies}"`;
+                console.log(`Executing PurpleA11y scan command:\n> ${command}\n`);
+                runPurpleA11yScan(command);
+            })
+            .catch((err: Error) => {
+                console.error('Error:', err);
+            });
+    };
+
+    runScript();   
 
 </details>

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -139,13 +139,16 @@ With reference to an instance of Purple A11y as `purpleA11y`:
 
 We will be creating the following files in a demo Cypress project:
 
-    ├── cypress
-    │   ├── e2e
-    │   │   └── spec.cy.js
-    │   └── support
-    │       └── e2e.js
-    ├── cypress.config.js
-    └── package.json
+    ├── cypress.config.ts
+    ├── cypress.d.ts
+    ├── package.json
+    ├── src
+    │   └── cypress
+    │       ├── e2e
+    │       │   └── spec.cy.ts
+    │       └── support
+    │           └── e2e.ts
+    └── tsconfig.json
 
 Create a <code>package.json</code> by running <code>npm init</code> . Accept the default options or customise it as needed.
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -211,7 +211,7 @@ Create <code>cypress.config.js</code> with the following contents, and change yo
         },
     });
 
-Create a sub-folder and file <code>cypress/support/e2e.js</code> with the following contents::
+Create a sub-folder and file <code>cypress/support/e2e.js</code> with the following contents:
 
     Cypress.Commands.add("injectPurpleA11yScripts", () => {
         cy.task("getPurpleA11yScripts").then((s) => {
@@ -278,7 +278,7 @@ Create a <code>package.json</code> by running <code>npm init</code> . Accept the
 
 Change the type of npm package to module by running <code>npm pkg set type="module"</code>
 
-Install the following node dependencies by running <code>npm install cypress @govtechsg/purple-hats typescript --save-dev </code>
+Install the following node dependencies by running <code>npm install cypress @types/cypress @govtechsg/purple-hats typescript --save-dev </code>
 
 Create a <code>tsconfig.json</code> in the root directory and add the following:
 ```
@@ -289,7 +289,8 @@ Create a <code>tsconfig.json</code> in the root directory and add the following:
     "target": "es2021",
     "module": "nodenext",
     "rootDir": "./src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["cypress"]
     },
     "include": ["./src/**/*"]
     }
@@ -355,10 +356,10 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
         },
     });
 
-Create a sub-folder and file <code>src/cypress/support/e2e.ts</code> with the following contents::
+Create a sub-folder and file <code>src/cypress/support/e2e.ts</code> with the following contents:
 
     Cypress.Commands.add("injectPurpleA11yScripts", () => {
-        cy.task("getPurpleA11yScripts").then((s) => {
+        cy.task("getPurpleA11yScripts").then((s: string) => {
             cy.window().then((win) => {
                 win.eval(s);
             });
@@ -400,6 +401,7 @@ Create <code>src/cypress/e2e/spec.cy.ts</code> with the following contents:
         });
     });
 
+Run your test with <code>npx tsc</code> .
 Run your test with <code>npx cypress run</code> .
 
 You will see Purple A11y results generated in <code>results</code> folder.

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -308,12 +308,26 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
     import { defineConfig } from "cypress";
     import purpleA11yInit from "@govtechsg/purple-hats";
 
+    interface ViewportSettings {
+        width: number;
+        height: number;
+    }
+
+    interface Thresholds {
+        mustFix: number;
+        goodToFix: number;
+    }
+
+    interface ScanAboutMetadata {
+        browser: string;
+    }
+
     // viewport used in tests to optimise screenshots
-    const viewportSettings = { width: 1920, height: 1040 };
+    const viewportSettings: ViewportSettings = { width: 1920, height: 1040 };
     // specifies the number of occurrences before error is thrown for test failure
-    const thresholds = { mustFix: 20, goodToFix: 25 };
+    const thresholds: Thresholds = { mustFix: 20, goodToFix: 20 };
     // additional information to include in the "Scan About" section of the report
-    const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
+    const scanAboutMetadata: ScanAboutMetadata = { browser: 'Chrome (Desktop)' };
 
     const purpleA11y = await purpleA11yInit(
         "https://govtechsg.github.io", // initial url to start scan
@@ -333,20 +347,20 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
         e2e: {
             setupNodeEvents(on, _config) {
                 on("task", {
-                    getPurpleA11yScripts() {
+                    getPurpleA11yScripts(): string {
                         return purpleA11y.getScripts();
                     },
-                    async pushPurpleA11yScanResults({res, metadata, elementsToClick}) {
+                    async pushPurpleA11yScanResults({res, metadata, elementsToClick}: { res: any, metadata: any, elementsToClick: any[] }): Promise<{ mustFix: number, goodToFix: number }> {
                         return await purpleA11y.pushScanResults(res, metadata, elementsToClick);
                     },
-                    returnResultsDir() {
+                    returnResultsDir(): string {
                         return `results/${purpleA11y.randomToken}_${purpleA11y.scanDetails.urlsCrawled.scanned.length}pages/reports/report.html`;
                     },
-                    finishPurpleA11yTestCase() {
+                    finishPurpleA11yTestCase(): null {
                         purpleA11y.testThresholds();
                         return null;
                     },
-                    async terminatePurpleA11y() {
+                    async terminatePurpleA11y(): Promise<null> {
                         return await purpleA11y.terminate();
                     },
                 });

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -268,17 +268,32 @@ We will be creating the following files in a demo Cypress project:
 
     ├── cypress
     │   ├── e2e
-    │   │   └── spec.cy.js
+    │   │   └── spec.cy.ts
     │   └── support
-    │       └── e2e.js
-    ├── cypress.config.js
+    │       └── e2e.ts
+    ├── cypress.config.ts
     └── package.json
 
 Create a <code>package.json</code> by running <code>npm init</code> . Accept the default options or customise it as needed.
 
 Change the type of npm package to module by running <code>npm pkg set type="module"</code>
 
-Install the following node dependencies by running <code>npm install cypress @govtechsg/purple-hats --save-dev </code>
+Install the following node dependencies by running <code>npm install cypress @govtechsg/purple-hats typescript --save-dev </code>
+
+Create a <code>tsconfig.json</code> in the root directory and add the following:
+```
+    {
+    "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "es2021",
+    "module": "nodenext",
+    "rootDir": "./src",
+    "skipLibCheck": true
+    },
+    "include": ["./src/**/*"]
+    }
+```
 
 Navigate to <code>node_modules/@govtechsg/purple-hats</code> and run <code>npm install</code> and <code>npm run build</code> within the folder to install remaining Purple A11y dependencies:
 
@@ -287,7 +302,7 @@ Navigate to <code>node_modules/@govtechsg/purple-hats</code> and run <code>npm i
     npm run build
     cd ../../..
 
-Create <code>cypress.config.js</code> with the following contents, and change your Name, E-mail address, and boolean value for whether rule items requiring manual review in the report should be displayed below:
+Create <code>cypress.config.ts</code> with the following contents, and change your Name, E-mail address, and boolean value for whether rule items requiring manual review in the report should be displayed below:
 
     import { defineConfig } from "cypress";
     import purpleA11yInit from "@govtechsg/purple-hats";
@@ -335,10 +350,12 @@ Create <code>cypress.config.js</code> with the following contents, and change yo
                     },
                 });
             },
+            supportFile: 'dist/cypress/support/e2e.js',
+            specPattern: 'dist/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         },
     });
 
-Create a sub-folder and file <code>cypress/support/e2e.js</code> with the following contents::
+Create a sub-folder and file <code>src/cypress/support/e2e.ts</code> with the following contents::
 
     Cypress.Commands.add("injectPurpleA11yScripts", () => {
         cy.task("getPurpleA11yScripts").then((s) => {
@@ -362,7 +379,7 @@ Create a sub-folder and file <code>cypress/support/e2e.js</code> with the follow
         cy.task("terminatePurpleA11y");
     });
 
-Create <code>cypress/e2e/spec.cy.js</code> with the following contents:
+Create <code>src/cypress/e2e/spec.cy.ts</code> with the following contents:
 
     describe("template spec", () => {
         it("should run purple A11y", () => {


### PR DESCRIPTION
This PR adds typescript examples for the integration guide.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
