### PR TITLE
Allow Txt to be scanned and support for window path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/purple-hats",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/purple-hats",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/purple-hats",
   "main": "dist/npmIndex.js",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "type": "module",
   "imports": {
     "#root/*.js": "./dist/*.js"

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1020,7 +1020,7 @@ export const getLinksFromSitemap = async (
   }
 
   const requestList = Object.values(urls);
-
+  
   return requestList;
 };
 
@@ -1786,7 +1786,8 @@ function isValidHttpUrl(urlString) {
 }
 
 export const isFilePath = (url: string): boolean => {
-  return url.startsWith('file://') || url.startsWith('/');
+  const driveLetterPattern = /^[A-Z]:\//i;
+  return url.startsWith('file://') || url.startsWith('/') || driveLetterPattern.test(url);
 };
 
 export function convertLocalFileToPath(url: string): string {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1786,8 +1786,12 @@ function isValidHttpUrl(urlString) {
 }
 
 export const isFilePath = (url: string): boolean => {
-  const driveLetterPattern = /^[A-Z]:\//i;
-  return url.startsWith('file://') || url.startsWith('/') || driveLetterPattern.test(url);
+  const driveLetterPattern = /^[A-Z]:/i;
+  const backslashPattern = /\\/;
+  return url.startsWith('file://')  ||
+         url.startsWith('/')         ||
+         driveLetterPattern.test(url) || 
+         backslashPattern.test(url);
 };
 
 export function convertLocalFileToPath(url: string): string {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -988,7 +988,7 @@ export const getLinksFromSitemap = async (
           if (isLimitReached()) {
             break;
           }
-          if (childSitemapUrlText.endsWith('.xml')) {
+          if (childSitemapUrlText.endsWith('.xml') || childSitemapUrlText.endsWith('.txt')) {
             await fetchUrls(childSitemapUrlText); // Recursive call for nested sitemaps
           } else {
             addToUrlList(childSitemapUrlText); // Add regular URLs to the list

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -7,7 +7,6 @@ import {
   failedRequestHandler,
   isUrlPdf,
 } from './commonCrawlerFunc.js';
-
 import constants, { guiInfoStatusTypes, basicAuthRegex } from '../constants/constants.js';
 import {
   getLinksFromSitemap,
@@ -145,23 +144,13 @@ const crawlLocalFile = async (
   uuidToPdfMapping[pdfFileName] = trimmedUrl;
 
   if (!isUrlPdf(request.url)) {
-    let browserUsed;
-    // Playwright only supports chromium,firefox and webkit thus hardcoded to chromium
-    if (browser === 'chromium') {
-      browserUsed = await playwright.chromium.launch();
-    } else if (browser === 'firefox') {
-      browserUsed = await playwright.firefox.launch();
-    } else if (browser === 'webkit') {
-      browserUsed = await playwright.webkit.launch();
-    } else if (browser === 'chrome') {
-      browserUsed = await playwright.chromium.launch(); //chrome not supported, default to chromium
-    } else {
-      console.log('Browser not supported, please use chrome, chromium, firefox, webkit');
-      console.log(' ');
-      return;
-    }
-    const context = await browserUsed.newContext();
-    const page = await context.newPage();
+
+    const browserContext = await constants.launcher.launchPersistentContext('', {
+      headless: process.env.CRAWLEE_HEADLESS === '1',
+      ...getPlaywrightLaunchOptions(browser),
+    });
+  
+    const page = await browserContext.newPage();
     request.url = convertPathToLocalFile(request.url);
     await page.goto(request.url);
     const results = await runAxeScript(includeScreenshots, page, randomToken, null);

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -74,9 +74,9 @@ const crawlLocalFile = async (
   convertLocalFileToPath(sitemapUrl);
 
   // XML Files
-  if (!sitemapUrl.match(/\.xml$/i)) {
+  console.log((!sitemapUrl.match(/\.txt$/i)))
+  if (!(sitemapUrl.match(/\.xml$/i) || sitemapUrl.match(/\.txt$/i))) {
     linksFromSitemap = [new Request({ url: sitemapUrl })];
-    
   // Non XML file
   } else {
     const username = '';


### PR DESCRIPTION
- Allow txt to be scanned like xml sitemap
- Handle windows path for localFileScan such as /A-Z: and file:// as well as backslash paths

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions