### PR TITLE
fix: category selector tooltip class

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -139,16 +139,13 @@ With reference to an instance of Purple A11y as `purpleA11y`:
 
 We will be creating the following files in a demo Cypress project:
 
-    ├── cypress.config.ts
-    ├── cypress.d.ts
-    ├── package.json
-    ├── src
-    │   └── cypress
-    │       ├── e2e
-    │       │   └── spec.cy.ts
-    │       └── support
-    │           └── e2e.ts
-    └── tsconfig.json
+    ├── cypress
+    │   ├── e2e
+    │   │   └── spec.cy.js
+    │   └── support
+    │       └── e2e.js
+    ├── cypress.config.js
+    └── package.json
 
 Create a <code>package.json</code> by running <code>npm init</code> . Accept the default options or customise it as needed.
 
@@ -268,13 +265,16 @@ You will see Purple A11y results generated in <code>results</code> folder.
 
 We will be creating the following files in a demo Cypress project:
 
-    ├── cypress
-    │   ├── e2e
-    │   │   └── spec.cy.ts
-    │   └── support
-    │       └── e2e.ts
     ├── cypress.config.ts
-    └── package.json
+    ├── cypress.d.ts
+    ├── package.json
+    ├── src
+    │   └── cypress
+    │       ├── e2e
+    │       │   └── spec.cy.ts
+    │       └── support
+    │           └── e2e.ts
+    └── tsconfig.json
 
 Create a <code>package.json</code> by running <code>npm init</code> . Accept the default options or customise it as needed.
 

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -124,7 +124,7 @@
                 const svgIcon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
                 svgIcon.setAttribute("tabindex", "-1");
                 svgIcon.id = `${category}Description`;
-                svgIcon.className = "ms-2";
+                svgIcon.setAttribute("class", "ms-2");
                 svgIcon.setAttribute("data-bs-toggle", "tooltip");
                 svgIcon.setAttribute("data-bs-placement", "top");
                 svgIcon.setAttribute("title", categoryData.description);


### PR DESCRIPTION
 ## Fixes
 - (report html) category selector tooltip class attribute
 - (integration.md) cypress example file structure

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
