### PR TITLE
Add a new Error "notALocalFile" for new Scan Mode "crawlLocalFile"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -284,12 +284,18 @@ const scanInit = async (argvs: Answers): Promise<string> => {
           process.exit(0);
         }
         break;
-      } else {
+      } else if (argvs.scanner === ScannerTypes.LOCALFILE) {
+        printMessage([statuses.notALocalFile.message], messageOptions);
+        process.exit(statuses.notALocalFile.code);
+      } else if (argvs.scanner !== ScannerTypes.SITEMAP) {
         printMessage([statuses.notASitemap.message], messageOptions);
         process.exit(statuses.notASitemap.code);
       }
     case statuses.notASitemap.code:
       printMessage([statuses.notASitemap.message], messageOptions);
+      process.exit(res.status);
+    case statuses.notALocalFile.code:
+      printMessage([statuses.notALocalFile.message], messageOptions);
       process.exit(res.status);
     case statuses.browserError.code:
       printMessage([statuses.browserError.message], messageOptions);

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -528,12 +528,14 @@ export const checkUrl = async (
   }
 
   if (
-    (res.status === constants.urlCheckStatuses.success.code && scanner === ScannerTypes.SITEMAP) ||
-    (res.status === constants.urlCheckStatuses.success.code && scanner === ScannerTypes.LOCALFILE)
-  ) {
+    res.status === constants.urlCheckStatuses.success.code && 
+    (scanner === ScannerTypes.SITEMAP || scanner === ScannerTypes.LOCALFILE)
+) {
     const isSitemap = isSitemapContent(res.content);
 
-    if (!isSitemap) {
+    if (!isSitemap && scanner === ScannerTypes.LOCALFILE) {
+      res.status = constants.urlCheckStatuses.notALocalFile.code;
+    } else if (!isSitemap){
       res.status = constants.urlCheckStatuses.notASitemap.code;
     }
   }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -359,6 +359,7 @@ const urlCheckStatuses = {
       'No browser available to run scans. Please ensure you have Chrome or Edge (for Windows only) installed.',
   },
   axiosTimeout: { code: 18, message: 'Axios timeout exceeded. Falling back on browser checks.' },
+  notALocalFile: { code: 19, message: 'Provided filepath is not a local html or sitemap file.' },
 };
 
 export enum BrowserTypes {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -351,7 +351,7 @@ const urlCheckStatuses = {
     code: 14,
     message: 'Something went wrong when verifying the URL. Please try again later.',
   },
-  notASitemap: { code: 15, message: 'Provided URL or filepath is not a sitemap.' },
+  notASitemap: { code: 15, message: 'Provided URL is not a sitemap.' },
   unauthorised: { code: 16, message: 'Provided URL needs basic authorisation.' },
   browserError: {
     code: 17,

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -29,7 +29,7 @@ const startScanQuestions = [
       { name: 'Website', value: ScannerTypes.WEBSITE },
       { name: 'Custom', value: ScannerTypes.CUSTOM },
       { name: 'Intelligent', value: ScannerTypes.INTELLIGENT },
-      { name: 'Localfile', value: ScannerTypes.LOCALFILE},
+      { name: 'Localfile', value: ScannerTypes.LOCALFILE },
     ],
   },
   {
@@ -117,11 +117,15 @@ const startScanQuestions = [
             answers.isLocalFileScan = true;
             answers.finalUrl = finalFilePath;
             return true;
+          } else if (answers.scanner === ScannerTypes.LOCALFILE) {
+            return statuses.notALocalFile.message;
           } else {
             return statuses.notASitemap.message;
           }
         case statuses.notASitemap.code:
           return statuses.notASitemap.message;
+        case statuses.notALocalFile.code:
+          return statuses.notALocalFile.message;
       }
     },
     filter: (input: string) => sanitizeUrlInput(input.trim()).url,


### PR DESCRIPTION
- Added a new Error "notALocalFile" with message "Provided filepath is not a local html or sitemap file."
- Replaced the error message of "notASitemap" to "Provided URL is not a sitemap." 

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions