### PR TITLE
Improvements and Bugfixes for Local File Scan Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "print-message": "^3.0.1",
         "safe-regex": "^2.1.1",
         "typescript": "^5.4.5",
+        "url": "^0.11.3",
         "validator": "^13.11.0",
         "which": "^4.0.0",
         "winston": "^3.11.0",
@@ -3055,13 +3056,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3611,16 +3617,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-properties": {
@@ -3888,6 +3897,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-set-tostringtag": {
@@ -4843,14 +4871,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5109,11 +5141,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7153,7 +7185,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7814,6 +7845,20 @@
         }
       ]
     },
+    "node_modules/qs": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -8222,14 +8267,16 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8269,14 +8316,17 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8974,6 +9024,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -8982,6 +9041,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "print-message": "^3.0.1",
     "safe-regex": "^2.1.1",
     "typescript": "^5.4.5",
+    "url": "^0.11.3",
     "validator": "^13.11.0",
     "which": "^4.0.0",
     "winston": "^3.11.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -284,12 +284,18 @@ const scanInit = async (argvs: Answers): Promise<string> => {
           process.exit(0);
         }
         break;
-      } else {
+      } else if (argvs.scanner === ScannerTypes.LOCALFILE) {
+        printMessage([statuses.notALocalFile.message], messageOptions);
+        process.exit(statuses.notALocalFile.code);
+      } else if (argvs.scanner !== ScannerTypes.SITEMAP) {
         printMessage([statuses.notASitemap.message], messageOptions);
         process.exit(statuses.notASitemap.code);
       }
     case statuses.notASitemap.code:
       printMessage([statuses.notASitemap.message], messageOptions);
+      process.exit(res.status);
+    case statuses.notALocalFile.code:
+      printMessage([statuses.notALocalFile.message], messageOptions);
       process.exit(res.status);
     case statuses.browserError.code:
       printMessage([statuses.browserError.message], messageOptions);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -198,7 +198,7 @@ Usage: npm run cli -- -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     return allHeaders;
   })
   .check(argvs => {
-    if (argvs.scanner === ScannerTypes.CUSTOM || argvs.scanner === ScannerTypes.LOCALFILE && argvs.maxpages) {
+    if ((argvs.scanner === ScannerTypes.CUSTOM || argvs.scanner === ScannerTypes.LOCALFILE) && argvs.maxpages) {
       throw new Error('-p or --maxpages is only available in website and sitemap scans.');
     }
     return true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -198,7 +198,7 @@ Usage: npm run cli -- -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     return allHeaders;
   })
   .check(argvs => {
-    if (argvs.scanner === ScannerTypes.CUSTOM && argvs.maxpages) {
+    if (argvs.scanner === ScannerTypes.CUSTOM || argvs.scanner === ScannerTypes.LOCALFILE && argvs.maxpages) {
       throw new Error('-p or --maxpages is only available in website and sitemap scans.');
     }
     return true;

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -63,8 +63,7 @@ const combineRun = async (details:Data, deviceToScan:string) => {
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
   const host =
-     (type === ScannerTypes.SITEMAP && isLocalFileScan) ||
-     (type === ScannerTypes.LOCALFILE && isLocalFileScan)
+     (type === ScannerTypes.SITEMAP || type === ScannerTypes.LOCALFILE)
        ? ''
        : getHost(url);
 
@@ -78,7 +77,7 @@ const combineRun = async (details:Data, deviceToScan:string) => {
   }
 
   // remove basic-auth credentials from URL
-  let finalUrl = (!(type === ScannerTypes.SITEMAP && isLocalFileScan || type === ScannerTypes.LOCALFILE && isLocalFileScan)) ? urlWithoutAuth(url) : new URL(pathToFileURL(url));
+  let finalUrl = (!(type === ScannerTypes.SITEMAP|| type === ScannerTypes.LOCALFILE)) ? urlWithoutAuth(url) : new URL(pathToFileURL(url));
   
   //Use the string version of finalUrl to reduce logic at submitForm
   let finalUrlString = finalUrl.toString();

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -10,6 +10,7 @@ import crawlee, { Request } from 'crawlee';
 import { parseString } from 'xml2js';
 import fs from 'fs';
 import path from 'path';
+import url from 'url';
 import safe from 'safe-regex';
 import * as https from 'https';
 import os from 'os';
@@ -223,6 +224,8 @@ export const getFileSitemap = (filePath: string): string | null => {
       filePath = filePath.match(/^file:\/\/(\/[^?#]+)/)?.[1];
     }
   }
+
+  filePath = convertToFilePath(filePath);
 
   if (!fs.existsSync(filePath)) {
     return null;
@@ -1809,3 +1812,12 @@ export function convertPathToLocalFile(filePath: string): string {
   }
   return filePath;
 } 
+
+export function convertToFilePath(fileUrl) {
+  // Parse the file URL
+  const parsedUrl = url.parse(fileUrl);
+  // Decode the URL-encoded path
+  const filePath = decodeURIComponent(parsedUrl.path);
+  // Return the file path without the 'file://' prefix
+  return filePath;
+}

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -528,12 +528,14 @@ export const checkUrl = async (
   }
 
   if (
-    (res.status === constants.urlCheckStatuses.success.code && scanner === ScannerTypes.SITEMAP) ||
-    (res.status === constants.urlCheckStatuses.success.code && scanner === ScannerTypes.LOCALFILE)
-  ) {
+    res.status === constants.urlCheckStatuses.success.code && 
+    (scanner === ScannerTypes.SITEMAP || scanner === ScannerTypes.LOCALFILE)
+) {
     const isSitemap = isSitemapContent(res.content);
 
-    if (!isSitemap) {
+    if (!isSitemap && scanner === ScannerTypes.LOCALFILE) {
+      res.status = constants.urlCheckStatuses.notALocalFile.code;
+    } else if (!isSitemap){
       res.status = constants.urlCheckStatuses.notASitemap.code;
     }
   }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -359,6 +359,7 @@ const urlCheckStatuses = {
       'No browser available to run scans. Please ensure you have Chrome or Edge (for Windows only) installed.',
   },
   axiosTimeout: { code: 18, message: 'Axios timeout exceeded. Falling back on browser checks.' },
+  notALocalFile: { code: 19, message: 'Provided filepath is not a local html or sitemap file.' },
 };
 
 export enum BrowserTypes {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -351,7 +351,7 @@ const urlCheckStatuses = {
     code: 14,
     message: 'Something went wrong when verifying the URL. Please try again later.',
   },
-  notASitemap: { code: 15, message: 'Provided URL or filepath is not a sitemap.' },
+  notASitemap: { code: 15, message: 'Provided URL is not a sitemap.' },
   unauthorised: { code: 16, message: 'Provided URL needs basic authorisation.' },
   browserError: {
     code: 17,

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -29,7 +29,7 @@ const startScanQuestions = [
       { name: 'Website', value: ScannerTypes.WEBSITE },
       { name: 'Custom', value: ScannerTypes.CUSTOM },
       { name: 'Intelligent', value: ScannerTypes.INTELLIGENT },
-      { name: 'Localfile', value: ScannerTypes.LOCALFILE},
+      { name: 'Localfile', value: ScannerTypes.LOCALFILE },
     ],
   },
   {
@@ -117,11 +117,15 @@ const startScanQuestions = [
             answers.isLocalFileScan = true;
             answers.finalUrl = finalFilePath;
             return true;
+          } else if (answers.scanner === ScannerTypes.LOCALFILE) {
+            return statuses.notALocalFile.message;
           } else {
             return statuses.notASitemap.message;
           }
         case statuses.notASitemap.code:
           return statuses.notASitemap.message;
+        case statuses.notALocalFile.code:
+          return statuses.notALocalFile.message;
       }
     },
     filter: (input: string) => sanitizeUrlInput(input.trim()).url,

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -67,8 +67,21 @@ const crawlLocalFile = async (
 
   // Check if the sitemapUrl is a local file and if it exists
   if (!(isFilePath(sitemapUrl)) || !fs.existsSync(sitemapUrl)) {
-    return;
+    // Convert to an absolute path
+    let normalizedPath = path.resolve(sitemapUrl);
+    
+    // Normalize the path to handle different path separators
+    normalizedPath = path.normalize(normalizedPath);
+
+    // Check if the normalized path exists
+    if (!fs.existsSync(normalizedPath)) {
+      return;
+    }
+    
+    // At this point, normalizedPath is a valid and existing file path
+    sitemapUrl = normalizedPath;
   }
+
 
   // Checks if its in the right file format, and change it before placing into linksFromSitemap
   convertLocalFileToPath(sitemapUrl);

--- a/src/crawlers/pdfScanFunc.ts
+++ b/src/crawlers/pdfScanFunc.ts
@@ -213,7 +213,7 @@ export const runPdfScan = async randomToken => {
     '--format',
     'json',
     '-r', // recurse through directory
-    intermediateFolder,
+    `"${intermediateFolder}"`,
   ];
 
   const ls = spawnSync(veraPdfExe, veraPdfCmdArgs, { shell: true });


### PR DESCRIPTION
-  Handle spaces, special characters and brackets in filepath for localFileScan
-  Added checks on the -p flag for localFileScan
-  Added support of relative paths for localFileScan (But for nested sitemap, it will be another PR)

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions