### PR TITLE
Add base64 passed scan items and axeImpact, remove obsolete WCAG SC 4.1.1

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -330,7 +330,6 @@ const wcagLinks = {
   'WCAG 2.4.4': 'https://www.w3.org/TR/WCAG21/#link-purpose-in-context',
   'WCAG 3.1.1': 'https://www.w3.org/TR/WCAG21/#language-of-page',
   'WCAG 3.1.2': 'https://www.w3.org/TR/WCAG21/#labels-or-instructions',
-  'WCAG 4.1.1': 'https://www.w3.org/TR/WCAG21/#parsing',
   'WCAG 4.1.2': 'https://www.w3.org/TR/WCAG21/#name-role-value',
 };
 

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -643,8 +643,15 @@ export const generateArtifacts = async (
       },
     };
 
-    let { items, ...rest } = allIssues;
+    let { items, startTime, endTime, ...rest } = allIssues;
     let encodedScanItems = base64Encode(items);
+    let encodedStartTime = formatDateTimeForMassScanner(startTime);
+    let encodedEndTime = formatDateTimeForMassScanner(endTime);
+
+    // Adding encoded start time and end time to rest object
+    rest.encodedStartTime = encodedStartTime;
+    rest.encodedEndTime = encodedEndTime;
+
     let encodedScanData = base64Encode(rest);
 
     let scanSummaryMessage = {

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -647,6 +647,10 @@ export const generateArtifacts = async (
     let encodedScanItems = base64Encode(items);
     let encodedStartTime = formatDateTimeForMassScanner(startTime);
     let encodedEndTime = formatDateTimeForMassScanner(endTime);
+    rest.critical = axeImpactCount.critical;
+    rest.serious= axeImpactCount.serious;
+    rest.moderate= axeImpactCount.moderate;
+    rest.minor= axeImpactCount.minor;
 
     // Adding encoded start time and end time to rest object
     rest.encodedStartTime = encodedStartTime;

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -645,16 +645,16 @@ export const generateArtifacts = async (
 
     let { items, startTime, endTime, ...rest } = allIssues;
     let encodedScanItems = base64Encode(items);
-    let encodedStartTime = formatDateTimeForMassScanner(startTime);
-    let encodedEndTime = formatDateTimeForMassScanner(endTime);
+    let formattedStartTime = formatDateTimeForMassScanner(startTime);
+    let formattedEndTime = formatDateTimeForMassScanner(endTime);
     rest.critical = axeImpactCount.critical;
     rest.serious= axeImpactCount.serious;
     rest.moderate= axeImpactCount.moderate;
     rest.minor= axeImpactCount.minor;
 
     // Adding encoded start time and end time to rest object
-    rest.encodedStartTime = encodedStartTime;
-    rest.encodedEndTime = encodedEndTime;
+    rest.formattedStartTime = formattedStartTime;
+    rest.formattedEndTime = formattedEndTime;
 
     let encodedScanData = base64Encode(rest);
 

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -658,27 +658,13 @@ export const generateArtifacts = async (
 
     let encodedScanData = base64Encode(rest);
 
-    let scanSummaryMessage = {
-      type: 'scanSummary',
-      payload: [
-        `Must Fix: ${Object.keys(allIssues.items.mustFix.rules).length} ${Object.keys(allIssues.items.mustFix.rules).length === 1 ? 'issue' : 'issues'} / ${allIssues.items.mustFix.totalItems} ${allIssues.items.mustFix.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
-        `Good to Fix: ${Object.keys(allIssues.items.goodToFix.rules).length} ${Object.keys(allIssues.items.goodToFix.rules).length === 1 ? 'issue' : 'issues'} / ${allIssues.items.goodToFix.totalItems} ${allIssues.items.goodToFix.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
-        `Needs Review: ${Object.keys(allIssues.items.needsReview.rules).length} ${Object.keys(allIssues.items.needsReview.rules).length === 1 ? 'issue' : 'issues'} / ${allIssues.items.needsReview.totalItems} ${allIssues.items.needsReview.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
-        `Passed: ${allIssues.items.passed.totalItems} ${allIssues.items.passed.totalItems === 1 ? 'occurrence' : 'occurrences'}`,
-        `Results directory: ${storagePath}`,
-      ],
-    };
-
     let scanDetailsMessage = {
       type: 'scanDetailsMessage',
       payload: { scanData: encodedScanData, scanItems: encodedScanItems },
     };
 
     if (process.send){
-      process.send(JSON.stringify(scanSummaryMessage));
       process.send(JSON.stringify(scanDetailsMessage));
-    } else {
-      console.log('Scan Summary: ',scanData);
     }
 
   }

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -645,7 +645,7 @@ export const generateArtifacts = async (
 
     let { items, ...rest } = allIssues;
     let encodedScanItems = base64Encode(items);
-    let encodedScanData = base64Encode(scanData);
+    let encodedScanData = base64Encode(rest);
 
     let scanSummaryMessage = {
       type: 'scanSummary',

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -56,6 +56,7 @@ type AllIssues = {
     rules: string[];
   };
   startTime: Date;
+  endTime: Date;
   urlScanned: string;
   scanType: string;
   formatAboutStartTime: (dateString: any) => string;
@@ -83,7 +84,6 @@ type AllIssues = {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-let allIssues;
 
 const extractFileNames = async (directory: string): Promise<string[]> =>
   fs
@@ -241,8 +241,6 @@ const writeBase64 = async (allIssues, storagePath, htmlFilename = 'report.html')
 
   const htmlFilePath = path.join(storagePath, htmlFilename);
   let htmlContent = fs.readFileSync(htmlFilePath, 'utf8');
-
-  const allIssuesJson = JSON.stringify(allIssues);
 
   const headIndex = htmlContent.indexOf('</head>');
   const injectScript = `
@@ -527,6 +525,7 @@ export const generateArtifacts = async (
       rules: purpleAiRules,
     },
     startTime: scanDetails.startTime ? scanDetails.startTime : new Date(),
+    endTime: scanDetails.endTime ? scanDetails.endTime : new Date(),
     urlScanned,
     scanType,
     formatAboutStartTime,
@@ -617,7 +616,7 @@ export const generateArtifacts = async (
     let scanData = {
       url: allIssues.urlScanned,
       startTime: formatDateTimeForMassScanner(allIssues.startTime),
-      endTime: formatDateTimeForMassScanner(scanDetails ? scanDetails.endTime : new Date()),
+      endTime: formatDateTimeForMassScanner(allIssues.endTime),
       pagesScanned: allIssues.pagesScanned.length,
       wcagPassPercentage: allIssues.wcagPassPercentage,
       critical: axeImpactCount.critical,

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -614,9 +614,6 @@ export const generateArtifacts = async (
   if (process.env.PURPLE_A11Y_VERBOSE) {
     let axeImpactCount = getAxeImpactCount(allIssues);
 
-    let { items, ...rest } = allIssues;
-
-
     let scanData = {
       url: allIssues.urlScanned,
       startTime: formatDateTimeForMassScanner(allIssues.startTime),
@@ -647,8 +644,9 @@ export const generateArtifacts = async (
       },
     };
 
+    let { items, ...rest } = allIssues;
     let encodedScanItems = base64Encode(items);
-    let encodedScanData = base64Encode(rest);
+    let encodedScanData = base64Encode(scanData);
 
     let scanDataMessage = {
       type: 'scanData',

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -666,7 +666,6 @@ export const generateArtifacts = async (
     if (process.send){
       process.send(JSON.stringify(scanDetailsMessage));
     }
-
   }
 
   await writeCsv(allIssues, storagePath);

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -616,9 +616,6 @@ export const generateArtifacts = async (
 
     let { items, ...rest } = allIssues;
 
-    let encodedScanItems = base64Encode(items);
-    let encodedScanData = base64Encode(rest);
-
 
     let scanData = {
       url: allIssues.urlScanned,
@@ -649,6 +646,9 @@ export const generateArtifacts = async (
         occurrence: allIssues.items.passed.totalItems,
       },
     };
+
+    let encodedScanItems = base64Encode(items);
+    let encodedScanData = base64Encode(rest);
 
     let scanDataMessage = {
       type: 'scanData',

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -648,11 +648,6 @@ export const generateArtifacts = async (
     let encodedScanItems = base64Encode(items);
     let encodedScanData = base64Encode(scanData);
 
-    let scanDataMessage = {
-      type: 'scanData',
-      payload: scanData,
-    };
-
     let scanSummaryMessage = {
       type: 'scanSummary',
       payload: [
@@ -670,7 +665,6 @@ export const generateArtifacts = async (
     };
 
     if (process.send){
-      process.send(JSON.stringify(scanDataMessage));
       process.send(JSON.stringify(scanSummaryMessage));
       process.send(JSON.stringify(scanDetailsMessage));
     } else {

--- a/src/static/ejs/partials/components/summaryWcagCompliance.ejs
+++ b/src/static/ejs/partials/components/summaryWcagCompliance.ejs
@@ -74,7 +74,7 @@
                 aria-expanded="false"
                 aria-controls="wcagLinksAccordionContent"
               >
-                20 WCAG Success Criteria (A & AA)
+                19 WCAG Success Criteria (A & AA)
               </button>
             </div>
             <div

--- a/src/static/ejs/partials/components/wcagCompliance.ejs
+++ b/src/static/ejs/partials/components/wcagCompliance.ejs
@@ -62,7 +62,7 @@
                 aria-expanded="false"
                 aria-controls="wcagLinksAccordionContent"
               >
-                20 WCAG Success Criteria (A & AA)
+                19 WCAG Success Criteria (A & AA)
               </button>
             </div>
             <div


### PR DESCRIPTION
This PR adds pass encoded scan data with axeImpactCounts and scan items to runner.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
