### PR TITLE
Improvements to facilitate cypress tests

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -226,7 +226,6 @@ Create a sub-folder and file <code>cypress/support/e2e.js</code> with the follow
             const { elementsToScan, elementsToClick, metadata } = items;
             const res = await win.runA11yScan(elementsToScan);
             cy.task("pushPurpleA11yScanResults", {res, metadata, elementsToClick}).then((count) => { return count });
-            cy.task("pushPurpleA11yScanResults", {res, metadata, elementsToClick}).then((count) => { return count });
             cy.task("finishPurpleA11yTestCase"); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
         });
     });
@@ -386,7 +385,6 @@ Create a sub-folder and file <code>src/cypress/support/e2e.ts</code> with the fo
         cy.window().then(async (win) => {
             const { elementsToScan, elementsToClick, metadata } = items;
             const res = await win.runA11yScan(elementsToScan);
-            cy.task("pushPurpleA11yScanResults", {res, metadata, elementsToClick}).then((count) => { return count });
             cy.task("pushPurpleA11yScanResults", {res, metadata, elementsToClick}).then((count) => { return count });
             cy.task("finishPurpleA11yTestCase"); // test the accumulated number of issue occurrences against specified thresholds. If exceed, terminate purpleA11y instance.
         });

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -109,11 +109,11 @@ Returns:
 
 Checks the accumulated issue occurrences count against the specified threshold.
 
-- Terminates purpleA11y instance and throws an error if the number of accumulated mustFix or goodToFix issue occurrences exceeds either of the specified thresholds
+- Terminates purpleA11y instance and throws an error if the number of accumulated mustFix or goodToFix issue occurrences exceeds either of the specified thresholds.
 
 `async terminate()`
 
-Stops the Purple A11y instance and generates the scan report and other scan result artifacts
+Stops the Purple A11y instance and generates the scan report and other scan result artifacts. Returns the name of the generated folder containing the results.
 
 ### How to use
 
@@ -369,7 +369,7 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
                         purpleA11y.testThresholds();
                         return null;
                     },
-                    async terminatePurpleA11y(): Promise<null> {
+                    async terminatePurpleA11y(): Promise<string> {
                         return await purpleA11y.terminate();
                     },
                 });
@@ -429,7 +429,7 @@ declare namespace Cypress {
   interface Chainable<Subject> {
     injectPurpleA11yScripts(): Chainable<void>;
     runPurpleA11yScan(options?: PurpleA11yScanOptions): Chainable<void>;
-    terminatePurpleA11y(): Chainable<void>;
+    terminatePurpleA11y(): Chainable<any>;
   }
 
   interface PurpleA11yScanOptions {

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -52,6 +52,8 @@ Returns an instance of Purple A11y
   - Object containing the max number of mustFix or goodToFix issue occurrences before an error is thrown for test failure. Does not fail tests by default. Example: `{ mustFix: 1, goodToFix: 3 }`
 - `scanAboutMetadata` (optional)
   - Include additional information in the Scan About section of the report by passing in a JSON object.
+- `zip` (optional)
+  - Name of the generated zip of Purple A11y results at the end of scan. Defaults to "a11y-scan-results".
 
 #### Purple A11y Instance
 
@@ -171,6 +173,8 @@ Create <code>cypress.config.js</code> with the following contents, and change yo
     const thresholds = { mustFix: 20, goodToFix: 25 };
     // additional information to include in the "Scan About" section of the report
     const scanAboutMetadata = { browser: 'Chrome (Desktop)' };
+    // name of the generated zip of the results at the end of scan
+    const resultsZipName = "a11y-scan-results"
 
     const purpleA11y = await purpleA11yInit(
         "https://govtechsg.github.io", // initial url to start scan
@@ -181,6 +185,7 @@ Create <code>cypress.config.js</code> with the following contents, and change yo
         viewportSettings,
         thresholds,
         scanAboutMetadata,
+        resultsZipName
     );
 
     export default defineConfig({
@@ -329,6 +334,8 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
     const thresholds: Thresholds = { mustFix: 20, goodToFix: 20 };
     // additional information to include in the "Scan About" section of the report
     const scanAboutMetadata: ScanAboutMetadata = { browser: 'Chrome (Desktop)' };
+    // name of the generated zip of the results at the end of scan
+    const resultsZipName: string = "a11y-scan-results"
 
     const purpleA11y = await purpleA11yInit(
         "https://govtechsg.github.io", // initial url to start scan
@@ -339,6 +346,7 @@ Create <code>cypress.config.ts</code> with the following contents, and change yo
         viewportSettings,
         thresholds,
         scanAboutMetadata,
+        resultsZipName
     );
 
     export default defineConfig({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -380,7 +380,7 @@ const optionsAnswer: Answers = {
   blacklistedPatternsFilename: options['blacklistedPatternsFilename'],
   playwrightDeviceDetailsObject: options['playwrightDeviceDetailsObject'],
 };
-scanInit(optionsAnswer);
+await scanInit(optionsAnswer);
 process.exit(0);
 
 export { options };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -380,48 +380,7 @@ const optionsAnswer: Answers = {
   blacklistedPatternsFilename: options['blacklistedPatternsFilename'],
   playwrightDeviceDetailsObject: options['playwrightDeviceDetailsObject'],
 };
-
-scanInit(optionsAnswer).then(async (storagePath: string) => {
-  // Take option if set
-  if (typeof optionsAnswer.zip === 'string') {
-    constants.cliZipFileName = optionsAnswer.zip;
-
-    if (!optionsAnswer.zip.endsWith('.zip')) {
-      constants.cliZipFileName += '.zip';
-    }
-  }
-
-  await fs
-    .ensureDir(storagePath)
-    .then(() => {
-      zipResults(constants.cliZipFileName, storagePath);
-      const messageToDisplay = [
-        `Report of this run is at ${constants.cliZipFileName}`,
-        `Results directory is at ${storagePath}`,
-      ];
-
-      if (process.env.REPORT_BREAKDOWN === '1') {
-        messageToDisplay.push(
-          'Reports have been further broken down according to their respective impact level.',
-        );
-      }
-
-      if (process.send && process.env.PURPLE_A11Y_VERBOSE && process.env.REPORT_BREAKDOWN != '1') {
-        let zipFileNameMessage = {
-          type: 'zipFileName',
-          payload: `${constants.cliZipFileName}`,
-        };
-
-        process.send(JSON.stringify(zipFileNameMessage));
-      }
-
-      printMessage(messageToDisplay);
-
-      process.exit(0);
-    })
-    .catch(error => {
-      printMessage([`Error in zipping results: ${error}`]);
-    });
-});
+scanInit(optionsAnswer);
+process.exit(0);
 
 export { options };

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -57,6 +57,7 @@ const combineRun = async (details:Data, deviceToScan:string) => {
     customFlowLabel = 'Custom Flow',
     extraHTTPHeaders,
     safeMode,
+    zip
   } = envDetails;
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
@@ -210,6 +211,7 @@ const combineRun = async (details:Data, deviceToScan:string) => {
       customFlowLabel,
       undefined,
       scanDetails,
+      zip
     );
     const [name, email] = nameEmail.split(':');
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -574,6 +574,7 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     followRobots,
     header,
     safeMode,
+    zip
   } = argv;
 
   // construct filename for scan results
@@ -617,6 +618,7 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     followRobots,
     extraHTTPHeaders: header,
     safeMode,
+    zip
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export type Data = {
   extraHTTPHeaders: string;
   safeMode: boolean;
   userDataDirectory?: string;
+  zip?: string;
 };
 
 const runScan = async (answers: Answers) => {
@@ -115,12 +116,6 @@ const runScan = async (answers: Answers) => {
   // Delete dataset and request queues
   cleanUp(data.randomToken);
 
-  const storagePath = getStoragePath(data.randomToken);
-  const messageToDisplay = [
-    `Report of this run is at ${constants.cliZipFileName}`,
-    `Results directory is at ${storagePath}`,
-  ];
-  printMessage(messageToDisplay);
   process.exit(0);
 };
 

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -12,7 +12,7 @@ import {
   urlWithoutAuth,
 } from './constants/common.js';
 import { createCrawleeSubFolders, filterAxeResults } from './crawlers/commonCrawlerFunc.js';
-import { createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
+import { createAndUpdateResultsFolders, createDetailsAndLogs, getStoragePath } from './utils.js';
 import { generateArtifacts } from './mergeAxeResults.js';
 import { takeScreenshotForHTMLElements } from './screenshotFunc/htmlScreenshotFunc.js';
 import { silentLogger } from './logs.js';
@@ -206,6 +206,10 @@ export const init = async (
         scanAboutMetadata,
         scanDetails,
       );
+
+      printMessage([
+        `Results directory is at ${getStoragePath(randomToken)}`
+      ]);
 
       await submitForm(
         BrowserTypes.CHROMIUM, // browserToRun

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -12,7 +12,7 @@ import {
   urlWithoutAuth,
 } from './constants/common.js';
 import { createCrawleeSubFolders, filterAxeResults } from './crawlers/commonCrawlerFunc.js';
-import { createAndUpdateResultsFolders, createDetailsAndLogs, getStoragePath } from './utils.js';
+import { createAndUpdateResultsFolders, createDetailsAndLogs } from './utils.js';
 import { generateArtifacts } from './mergeAxeResults.js';
 import { takeScreenshotForHTMLElements } from './screenshotFunc/htmlScreenshotFunc.js';
 import { silentLogger } from './logs.js';
@@ -206,10 +206,6 @@ export const init = async (
         scanAboutMetadata,
         scanDetails,
       );
-
-      printMessage([
-        `Results directory is at ${getStoragePath(randomToken)}`
-      ]);
 
       await submitForm(
         BrowserTypes.CHROMIUM, // browserToRun

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -30,6 +30,7 @@ export const init = async (
   viewportSettings = { width: 1000, height: 660 }, // cypress' default viewport settings
   thresholds = { mustFix: undefined, goodToFix: undefined },
   scanAboutMetadata = undefined,
+  zip = undefined 
 ) => {
   console.log('Starting Purple A11y');
 
@@ -205,6 +206,7 @@ export const init = async (
         testLabel,
         scanAboutMetadata,
         scanDetails,
+        zip
       );
 
       await submitForm(

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -225,7 +225,7 @@ export const init = async (
       );
     }
 
-    return null;
+    return randomToken;
   };
 
   return {


### PR DESCRIPTION
## Improvements
 - Shifted logic of zipping results and printing result directory from cli.ts to mergeAxeResults.ts. This is so that when running scan from integration, results will be zipped and directory will be printed as well.
 - Added a parameter for purpleA11yInit() in npmIndex.ts to specify desired name of result zip.
 - Method terminate() in npmIndex.ts now returns the randomToken instead of null.
 - Updated integration.md accordingly.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
