### PR TITLE
feat: trigger page close to complete the custom flow

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -432,5 +432,5 @@ export const cssQuerySelectors = [
   ':not(a):is([role="link"]',
   'button[onclick])',
   'a:not([href])',
-  '[role="button"]', // Add this line to select elements with role="button"
+  '[role="button"]:not(a[href])', // Add this line to select elements with role="button" where it is not <a> with href
 ];

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -432,7 +432,8 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
       // Auto-clicks 'Scan this page' button only once
       if (isCypressTest) {
         try {
-          handleOnScanClick();
+          await handleOnScanClick();
+          page.close();
         } catch (e) {
           consoleLogger.info(`Error in calling handleOnScanClick, isCypressTest: ${isCypressTest}`);
         }


### PR DESCRIPTION
This PR adds:

- `await handleOnScanClick()` to ensure the function completes before calling
- `page.close()` method to complete the custom flow
-  add condition that `role=button` must not be `<a>` that has `href` for clickable elements

---

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
